### PR TITLE
fix(relay): use --onto rebase to only replay PR-specific commits

### DIFF
--- a/.github/workflows/relay-to-org.yml
+++ b/.github/workflows/relay-to-org.yml
@@ -118,6 +118,8 @@ jobs:
           set -euo pipefail
           git remote add upstream "https://x-access-token:${ORG_TOKEN}@github.com/${{ env.ORG_OWNER }}/${{ env.ORG_REPO }}.git"
           git fetch upstream "${{ env.RELAY_BASE }}"
+          # Fetch the PR's base branch from origin (the fork) for --onto rebase
+          git fetch origin "${{ steps.ctx.outputs.base_ref }}"
 
       - name: Rebase onto upstream base (auto-resolve infra/docs/LFS)
         id: rebase
@@ -126,7 +128,9 @@ jobs:
           set -euo pipefail
           export GIT_EDITOR=true
 
-          git rebase "upstream/${{ env.RELAY_BASE }}" || true
+          # Use --onto to only rebase PR-specific commits, not the entire fork history.
+          # This replays only commits between origin's base branch and HEAD onto upstream.
+          git rebase --onto "upstream/${{ env.RELAY_BASE }}" "origin/${{ steps.ctx.outputs.base_ref }}" HEAD || true
 
           allowlist=(
             ".devcontainer/"


### PR DESCRIPTION
The relay workflow was doing a full `git rebase upstream/staging` which tried to replay the entire fork history (1300+ commits) onto upstream. This caused conflicts because the mirror sync rewrites commits when stripping workflow files, creating diverged histories.

The fix uses `git rebase --onto` to only replay commits between the PR's base branch (origin/mirror/staging) and HEAD. This means only the actual PR commits are rebased, not the entire fork history.

Changes:
- Fetch origin's base branch (e.g., mirror/staging) before rebasing
- Use --onto syntax: rebase --onto upstream/staging origin/mirror/staging HEAD

https://claude.ai/code/session_0197c48GcqyW92ZGQ3Gm1WJw