### PR TITLE
fix(relay): disable credential helper to use PAT for push

### DIFF
--- a/.github/workflows/relay-to-org.yml
+++ b/.github/workflows/relay-to-org.yml
@@ -273,7 +273,8 @@ jobs:
         run: |
           set -euo pipefail
           RELAY_BRANCH="relay/hh-pr-${{ steps.ctx.outputs.pr_number }}"
-          git push "https://x-access-token:${ORG_TOKEN}@github.com/${{ env.ORG_OWNER }}/${{ env.ORG_REPO }}.git" HEAD:${RELAY_BRANCH} --force-with-lease
+          # Disable credential helper to ensure our PAT is used instead of the runner's token
+          git -c credential.helper= push "https://x-access-token:${ORG_TOKEN}@github.com/${{ env.ORG_OWNER }}/${{ env.ORG_REPO }}.git" HEAD:${RELAY_BRANCH} --force-with-lease
           echo "RELAY_BRANCH=${RELAY_BRANCH}" >> "$GITHUB_ENV"
 
       - name: Create or update PR in org


### PR DESCRIPTION
GitHub Actions runners have a built-in credential helper that was overriding the PAT authentication, causing pushes to fail with "Permission denied to github-actions[bot]".

Adding `-c credential.helper=` to the git push command disables the credential helper and ensures the PAT in the URL is used.

https://claude.ai/code/session_0197c48GcqyW92ZGQ3Gm1WJw