### PR TITLE
fix(relay): disable persisted credentials from checkout

### DIFF
--- a/.github/workflows/relay-to-org.yml
+++ b/.github/workflows/relay-to-org.yml
@@ -96,6 +96,7 @@ jobs:
           repository: ${{ steps.ctx.outputs.head_repo }}
           ref: ${{ steps.ctx.outputs.head_sha }}
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Configure Git
         run: |


### PR DESCRIPTION
The actions/checkout@v4 action persists credentials by default, which overrides the PAT in the URL even with credential.helper disabled.

Adding persist-credentials: false prevents this.

https://claude.ai/code/session_0197c48GcqyW92ZGQ3Gm1WJw