### PR TITLE
fix(relay): use full refspec for push

### DIFF
--- a/.github/workflows/relay-to-org.yml
+++ b/.github/workflows/relay-to-org.yml
@@ -275,7 +275,7 @@ jobs:
           set -euo pipefail
           RELAY_BRANCH="relay/hh-pr-${{ steps.ctx.outputs.pr_number }}"
           # Disable credential helper to ensure our PAT is used instead of the runner's token
-          git -c credential.helper= push "https://x-access-token:${ORG_TOKEN}@github.com/${{ env.ORG_OWNER }}/${{ env.ORG_REPO }}.git" HEAD:${RELAY_BRANCH} --force-with-lease
+          git -c credential.helper= push "https://x-access-token:${ORG_TOKEN}@github.com/${{ env.ORG_OWNER }}/${{ env.ORG_REPO }}.git" HEAD:refs/heads/${RELAY_BRANCH} --force-with-lease
           echo "RELAY_BRANCH=${RELAY_BRANCH}" >> "$GITHUB_ENV"
 
       - name: Create or update PR in org


### PR DESCRIPTION
Git requires the full refspec (refs/heads/...) when pushing to a branch that doesn't exist yet on the remote.

https://claude.ai/code/session_0197c48GcqyW92ZGQ3Gm1WJw