### PR TITLE
fix(relay): use --force instead of --force-with-lease for relay branch

### DIFF
--- a/.github/workflows/relay-to-org.yml
+++ b/.github/workflows/relay-to-org.yml
@@ -275,7 +275,7 @@ jobs:
           set -euo pipefail
           RELAY_BRANCH="relay/hh-pr-${{ steps.ctx.outputs.pr_number }}"
           # Disable credential helper to ensure our PAT is used instead of the runner's token
-          git -c credential.helper= push "https://x-access-token:${ORG_TOKEN}@github.com/${{ env.ORG_OWNER }}/${{ env.ORG_REPO }}.git" HEAD:refs/heads/${RELAY_BRANCH} --force-with-lease
+          git -c credential.helper= push "https://x-access-token:${ORG_TOKEN}@github.com/${{ env.ORG_OWNER }}/${{ env.ORG_REPO }}.git" HEAD:refs/heads/${RELAY_BRANCH} --force
           echo "RELAY_BRANCH=${RELAY_BRANCH}" >> "$GITHUB_ENV"
 
       - name: Create or update PR in org


### PR DESCRIPTION
The relay branch is intentionally overwritten on each sync, so --force-with-lease causes failures when the branch was previously updated. Using --force is safe here since we control this branch.

https://claude.ai/code/session_0197c48GcqyW92ZGQ3Gm1WJw