### PR TITLE
Claude/improve zyra poster

### DIFF
--- a/poster/html/zyra-poster-print.html
+++ b/poster/html/zyra-poster-print.html
@@ -1,0 +1,3141 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Zyra Conference Poster — 48×36″ Print (300 DPI)</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Source+Sans+3:ital,wght@0,300;0,400;0,500;0,600;0,700&family=Source+Code+Pro:wght@400;500;600&display=swap" rel="stylesheet">
+<style>
+
+/* ═══════════════════════════════════════════════════════════════════
+   PRINT LAYOUT — 48×36" poster at 300 DPI = 14400×10800px
+   ═══════════════════════════════════════════════════════════════════
+   FULLY SELF-CONTAINED — no dependency on _styles.css.
+
+   Structure:
+     Part 1 — Design tokens + reset
+     Part 2 — Component visual styles (colors, fonts, backgrounds)
+     Part 3 — Print layout overrides (grid, sizing, 300 DPI dimensions)
+
+   Typography (300 DPI, viewed from 3–4 ft):
+     120pt = 500px  — poster title / project name
+      48pt = 200px  — section headings
+      36pt = 150px  — subheadings
+      28pt = 117px  — body text (wide cols)
+      24pt = 100px  — body text (narrow cols), code
+      20pt =  83px  — captions, small text
+      16pt =  67px  — badges, tiny labels
+
+   Grid — 12 columns, 5 rows (total = 10800px):
+     Row 1 (1200px):  HEADER                             (12 cols)
+     Row 2 (2200px):  CHALLENGE (3)  |  PIPELINE (9)
+     Row 3 (2600px):  FEATURES (4)   |  REPRO (3)  |  FOUNDATION (5)
+     Row 4 (3100px):  NARRATION (3)  |  DROUGHT (5)  |  HRRR (4)
+     Row 5 (1700px):  NARRATION (3)  |  DROUGHT (5)  |  GET STARTED (4)
+   ═══════════════════════════════════════════════════════════════════ */
+
+
+/* ═══════════════════════════════════════════
+   PART 1 — DESIGN TOKENS + RESET
+   ═══════════════════════════════════════════ */
+:root {
+  /* Primary */
+  --navy:        #00172D;
+  --ocean-blue:  #1A5A69;
+  --cable-blue:  #00529E;
+  /* Accent */
+  --seafoam:     #5F9DAE;
+  --mist:        #9AB2B1;
+  --deep-teal:   #091A1B;
+  /* Earth */
+  --leaf-green:  #2C670C;
+  --olive:       #576216;
+  --soil:        #50452C;
+  /* Semantic */
+  --amber:       #FFC107;
+  --red:         #F44336;
+  /* Neutrals */
+  --neutral-900: #232323;
+  --neutral-700: #8B8985;
+  --neutral-600: #A3A29D;
+  --neutral-400: #D8D7D3;
+  --neutral-200: #F7F5EE;
+  --neutral-50:  #FEFEFE;
+  /* Typography */
+  --font-sans: 'Source Sans 3', 'Source Sans Pro', system-ui, -apple-system, sans-serif;
+  --font-mono: 'Source Code Pro', 'Fira Code', 'Consolas', monospace;
+}
+
+* { margin: 0; padding: 0; box-sizing: border-box; }
+
+body {
+  background: white;
+  padding: 0;
+  display: block;
+  font-family: var(--font-sans);
+}
+
+
+/* ═══════════════════════════════════════════
+   PART 2 — COMPONENT VISUAL STYLES
+   Colors, fonts, backgrounds, borders.
+   Print layout (Part 3) overrides dimensions.
+   ═══════════════════════════════════════════ */
+
+/* ── Header ── */
+.header {
+  position: relative;
+  overflow: hidden;
+  background: url('light-slide-background.png') center center / cover no-repeat;
+}
+.header::after {
+  content: '';
+  position: absolute;
+  bottom: 0; left: 0; right: 0;
+  height: 4px;
+  background: linear-gradient(90deg,
+    transparent 0%, var(--mist) 20%,
+    var(--seafoam) 50%, var(--mist) 80%,
+    transparent 100%);
+  z-index: 10;
+}
+.header-content {
+  position: relative;
+  z-index: 5;
+  display: flex;
+  align-items: stretch;
+}
+.header-left { display: none; }
+.header-right {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+  position: relative;
+}
+.header-dataviz {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  pointer-events: none;
+  overflow: hidden;
+}
+.header-dataviz svg {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+}
+.header-right > *:not(.header-dataviz) {
+  position: relative;
+  z-index: 1;
+}
+.project-name {
+  font-weight: 800;
+  color: var(--navy);
+  letter-spacing: -1.5px;
+}
+.poster-title {
+  font-weight: 600;
+  color: var(--ocean-blue);
+  letter-spacing: -0.3px;
+}
+.poster-subtitle {
+  font-weight: 400;
+  color: var(--neutral-700);
+  letter-spacing: 0.1px;
+}
+.vine-divider { opacity: 0.5; }
+.vine-divider img { width: 100%; height: 100%; object-fit: contain; }
+.author-block {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+.author-name { font-weight: 600; color: var(--neutral-900); }
+.author-org  { color: var(--neutral-700); }
+.author-orcid {
+  color: var(--neutral-600);
+  display: flex;
+  align-items: center;
+  gap: 5px;
+}
+.orcid-dot {
+  display: inline-flex;
+  border-radius: 50%;
+  background: #A6CE39;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+  color: #fff;
+}
+.badges { display: flex; flex-wrap: wrap; justify-content: center; }
+.badge {
+  display: inline-flex;
+  align-items: center;
+  font-weight: 500;
+  color: var(--navy);
+  background: rgba(254,254,254,0.92);
+  border: 1px solid var(--neutral-600);
+  text-decoration: none;
+  box-shadow: 0 1px 3px rgba(0,23,45,0.12);
+}
+.badge-pip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+  color: #fff;
+}
+.badge-pip svg { display: block; }
+.pip-pypi { background: #3775A9; }
+.pip-docs { background: var(--ocean-blue); }
+.pip-doi  { background: var(--amber); color: var(--navy); }
+.pip-lic  { background: var(--neutral-700); }
+.pip-gh   { background: var(--neutral-900); }
+.badge-label { color: var(--neutral-700); }
+.badge-value { font-weight: 600; color: var(--navy); }
+
+/* ── Section Tag (shared) ── */
+.section-tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+}
+.section-tag .diamond {
+  background: var(--cable-blue);
+  border-radius: 1.5px;
+  transform: rotate(45deg);
+  flex-shrink: 0;
+}
+.section-tag span {
+  font-family: var(--font-sans);
+  font-weight: 600;
+  letter-spacing: 1.5px;
+  text-transform: uppercase;
+  color: var(--cable-blue);
+}
+
+/* ── Challenge ── */
+.challenge-section { position: relative; }
+.challenge-card {
+  position: relative;
+  display: flex;
+  align-items: stretch;
+  overflow: hidden;
+}
+.challenge-frame {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  pointer-events: none;
+}
+.challenge-frame img { width: 100%; height: 100%; object-fit: fill; opacity: 0.10; }
+.challenge-inner {
+  position: relative;
+  z-index: 1;
+  width: 100%;
+  background: rgba(247, 245, 238, 0.85);
+  border-radius: 6px;
+}
+.challenge-inner::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: 6px;
+  background: repeating-linear-gradient(
+    135deg,
+    transparent, transparent 28px,
+    rgba(0,82,158,0.012) 28px,
+    rgba(0,82,158,0.012) 29px
+  );
+  pointer-events: none;
+}
+.challenge-text {
+  position: relative;
+  z-index: 1;
+}
+.challenge-heading {
+  font-family: var(--font-sans);
+  font-weight: 700;
+  color: var(--navy);
+  line-height: 1.25;
+  position: relative;
+  display: inline-block;
+}
+.challenge-heading::after {
+  content: '';
+  display: block;
+  width: 64px;
+  height: 3px;
+  background: linear-gradient(90deg, var(--cable-blue), var(--seafoam));
+  border-radius: 2px;
+  margin-top: 8px;
+  margin-bottom: 12px;
+}
+.challenge-body { position: relative; }
+.challenge-body p {
+  font-family: var(--font-sans);
+  font-weight: 400;
+  color: var(--neutral-900);
+}
+.challenge-body p + p { margin-top: 12px; }
+.em-bold { font-weight: 600; color: var(--navy); }
+.tok {
+  font-family: var(--font-mono);
+  font-weight: 500;
+  color: var(--cable-blue);
+  background: rgba(0,82,158,0.06);
+  border: 1px solid rgba(0,82,158,0.10);
+  letter-spacing: 0.3px;
+  white-space: nowrap;
+}
+.challenge-graphic {
+  position: relative;
+  z-index: 1;
+}
+.cg-node {
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  font-weight: 600;
+  letter-spacing: 0.4px;
+}
+.cg-label {
+  font-family: var(--font-sans);
+  font-size: 9.5px;
+  font-weight: 600;
+  letter-spacing: 1.2px;
+  text-transform: uppercase;
+}
+
+/* ── Pipeline ── */
+.pipeline-heading {
+  font-family: var(--font-sans);
+  font-weight: 700;
+  color: var(--navy);
+  line-height: 1.25;
+}
+.pipeline-sub {
+  font-family: var(--font-sans);
+  color: var(--neutral-700);
+}
+.pipeline-visual-wrap {
+  width: 100%;
+  overflow: hidden;
+  position: relative;
+}
+.pipeline-visual {
+  position: relative;
+  background: var(--neutral-50);
+  border-radius: 0;
+  border: none;
+  overflow: visible;
+  transform-origin: top left;
+}
+.pipeline-visual .flow-bg {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+}
+.phase-label {
+  position: absolute;
+  font-family: var(--font-sans);
+  font-weight: 700;
+  letter-spacing: -0.2px;
+  z-index: 5;
+}
+.pl-ingest { top: 16px; left: 55px; color: var(--cable-blue); }
+.pl-viz    { top: 16px; left: 510px; color: var(--ocean-blue); }
+.pl-export { top: 16px; right: 95px; color: var(--leaf-green); }
+.source-stack {
+  position: absolute;
+  left: 25px; top: 110px;
+  display: flex; flex-direction: column; gap: 22px;
+  z-index: 5;
+}
+.output-stack {
+  position: absolute;
+  right: 20px; top: 100px;
+  display: flex; flex-direction: column; gap: 22px;
+  z-index: 5;
+}
+.source-item { display: flex; align-items: center; gap: 9px; }
+.source-icon {
+  border-radius: 12px;
+  display: flex; align-items: center; justify-content: center;
+  box-shadow: 0 3px 12px rgba(0,0,0,0.07);
+}
+.source-label {
+  font-family: var(--font-sans);
+  font-weight: 700;
+  color: var(--navy);
+}
+.stage-bubble {
+  position: absolute;
+  z-index: 10;
+  text-align: center;
+}
+.stage-circle {
+  border-radius: 50%;
+  display: flex; align-items: center; justify-content: center;
+  margin: 0 auto;
+  box-shadow: 0 5px 20px rgba(0,0,0,0.11);
+  position: relative;
+}
+.stage-circle.planned {
+  box-shadow: 0 3px 12px rgba(0,0,0,0.05);
+  border: 2.5px dashed var(--neutral-700);
+  background: rgba(139,137,133,0.12) !important;
+}
+.stage-label-txt {
+  font-family: var(--font-sans);
+  font-weight: 700;
+  margin-top: 5px;
+  color: var(--navy);
+}
+.stage-cli-txt {
+  font-family: var(--font-mono);
+  color: var(--cable-blue);
+  background: rgba(0,82,158,0.07);
+  border-radius: 3px;
+  padding: 1px 6px;
+  display: inline-block;
+  margin-top: 2px;
+}
+.stage-cli-txt.planned-cli {
+  color: var(--neutral-700);
+  background: rgba(139,137,133,0.12);
+}
+.callout {
+  position: absolute;
+  z-index: 15;
+  background: white;
+  border-radius: 10px;
+  padding: 12px 14px;
+  box-shadow: 0 3px 16px rgba(0,0,0,0.07), 0 1px 3px rgba(0,0,0,0.03);
+  max-width: 200px;
+}
+.callout-arrow {
+  position: absolute;
+  top: -5px;
+  width: 10px; height: 10px;
+  background: white;
+  transform: rotate(45deg);
+  box-shadow: -1px -1px 2px rgba(0,0,0,0.03);
+}
+.callout-title, .callout-text { position: relative; z-index: 2; }
+.callout-title {
+  font-family: var(--font-sans);
+  font-weight: 700;
+  color: var(--navy);
+  margin-bottom: 3px;
+  display: flex; align-items: center; gap: 5px;
+}
+.ct-tag {
+  font-family: var(--font-mono);
+  font-weight: 600;
+  color: white;
+  border-radius: 3px;
+}
+.callout-text {
+  font-family: var(--font-sans);
+  color: var(--neutral-700);
+  line-height: 1.4;
+}
+.format-pills {
+  position: absolute;
+  display: flex; gap: 5px;
+  z-index: 12;
+}
+.fpill {
+  font-family: var(--font-mono);
+  font-weight: 600;
+  color: white;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.1);
+}
+.phase-summaries {
+  position: absolute;
+  bottom: 8px;
+  left: 0; right: 0;
+  display: flex;
+  z-index: 5;
+}
+.phase-summary {
+  flex: 1;
+  text-align: center;
+  font-family: var(--font-sans);
+  color: var(--neutral-700);
+  line-height: 1.4;
+  padding: 0 36px;
+}
+
+/* ── Use Case Cards ── */
+.usecase-card {
+  background: var(--neutral-50);
+  border: 1px solid var(--neutral-400);
+  border-left: 4px solid var(--cable-blue);
+  position: relative;
+}
+.usecase-heading {
+  font-family: var(--font-sans);
+  font-weight: 700;
+  color: var(--ocean-blue);
+  line-height: 1.3;
+}
+.usecase-desc {
+  font-family: var(--font-sans);
+  color: var(--neutral-900);
+  line-height: 1.55;
+}
+.usecase-code {
+  background: var(--neutral-200);
+  border: 1px solid var(--neutral-400);
+  border-radius: 6px;
+  font-family: var(--font-mono);
+  color: var(--neutral-900);
+  white-space: pre;
+  overflow-x: auto;
+  position: relative;
+}
+.usecase-code::after {
+  content: 'bash';
+  position: absolute;
+  font-family: var(--font-mono);
+  font-weight: 500;
+  color: var(--neutral-600);
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
+}
+.usecase-code .cc-cmd  { color: var(--cable-blue); font-weight: 600; }
+.usecase-code .cc-url  { color: var(--ocean-blue); }
+.usecase-code .cc-flag { color: var(--olive); }
+.usecase-code .cc-file { color: var(--leaf-green); font-weight: 500; }
+.code-steps {
+  display: flex;
+  flex-direction: column;
+}
+.code-step {
+  display: flex;
+  align-items: flex-start;
+  background: var(--neutral-200);
+  border: 1px solid var(--neutral-400);
+  border-bottom: none;
+  position: relative;
+}
+.code-step:first-child { border-radius: 6px 6px 0 0; }
+.code-step:last-child {
+  border-bottom: 1px solid var(--neutral-400);
+  border-radius: 0 0 6px 6px;
+}
+.code-step::after {
+  content: 'bash';
+  position: absolute;
+  font-family: var(--font-mono);
+  font-weight: 500;
+  color: var(--neutral-600);
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
+  display: none;
+}
+.code-step:first-child::after { display: block; }
+.step-dot {
+  flex-shrink: 0;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--font-sans);
+  font-weight: 700;
+  color: #fff;
+  box-shadow: 0 3px 10px rgba(0,0,0,0.12);
+}
+.step-dot-import    { background: linear-gradient(135deg, var(--cable-blue), #003d7a); }
+.step-dot-process   { background: linear-gradient(135deg, var(--leaf-green), #1a4a08); }
+.step-dot-visualize { background: linear-gradient(135deg, var(--olive), #3a4510); }
+.step-dot-export    { background: linear-gradient(135deg, var(--cable-blue), #003d7a); }
+.step-dot-search    { background: linear-gradient(135deg, var(--seafoam), #3d7585); }
+.step-stage-tag {
+  display: inline-block;
+  font-family: var(--font-mono);
+  font-weight: 600;
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
+}
+.step-stage-tag.tag-import    { background: rgba(0,82,158,0.1); color: var(--cable-blue); }
+.step-stage-tag.tag-process   { background: rgba(44,103,12,0.1); color: var(--leaf-green); }
+.step-stage-tag.tag-visualize { background: rgba(87,98,22,0.1); color: var(--olive); }
+.step-stage-tag.tag-export    { background: rgba(0,82,158,0.1); color: var(--cable-blue); }
+.step-stage-tag.tag-search    { background: rgba(95,157,174,0.12); color: var(--seafoam); }
+.step-code {
+  font-family: var(--font-mono);
+  color: var(--neutral-900);
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+.flow-connector {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--neutral-600);
+}
+.flow-connector svg { opacity: 0.5; }
+
+/* HRRR watermark */
+.hrrr-card { position: relative; overflow: hidden; }
+.hrrr-card::before {
+  content: '';
+  position: absolute;
+  top: 50%; right: -20px;
+  width: 200px; height: 140px;
+  background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 200 140'%3E%3Cpath d='M30,20 Q40,15 55,18 L70,15 Q85,12 95,18 L110,22 Q125,20 140,15 L155,18 Q168,22 175,28 L178,35 Q180,45 175,55 L170,65 Q165,72 160,78 L155,85 Q148,92 140,95 L130,98 Q118,102 105,100 L90,95 Q78,90 68,85 L55,80 Q42,75 35,68 L28,58 Q22,48 25,38 L28,28 Q28,22 30,20Z' fill='none' stroke='%231A5A69' stroke-width='0.8' opacity='0.06'/%3E%3C/svg%3E") no-repeat center center;
+  background-size: contain;
+  pointer-events: none;
+  opacity: 0.5;
+}
+
+/* Placeholder / caption */
+.usecase-placeholder {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  color: var(--neutral-600);
+}
+.usecase-placeholder svg { opacity: 0.35; }
+.usecase-placeholder span {
+  font-family: var(--font-sans);
+  font-weight: 500;
+}
+.usecase-caption {
+  font-family: var(--font-sans);
+  font-style: italic;
+  color: var(--neutral-700);
+  text-align: center;
+}
+.usecase-caption code {
+  font-family: var(--font-mono);
+  font-style: normal;
+  color: var(--cable-blue);
+  background: rgba(0,82,158,0.06);
+  padding: 0 4px;
+  border-radius: 2px;
+}
+
+/* DAG diagram */
+.dag-wrap {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+.dag-node { display: flex; align-items: center; gap: 10px; width: 100%; }
+.dag-box {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  color: white;
+  font-family: var(--font-mono);
+  font-weight: 600;
+  letter-spacing: 0.2px;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.08);
+}
+.dag-box svg { flex-shrink: 0; }
+.dag-stage-tag {
+  font-family: var(--font-sans);
+  font-weight: 500;
+  color: var(--neutral-600);
+  white-space: nowrap;
+  text-align: right;
+}
+.dag-arrow { display: flex; justify-content: center; }
+.dag-arrow svg { opacity: 0.4; }
+
+/* Video preview */
+.video-preview {
+  display: block;
+  overflow: hidden;
+  border: 1px solid var(--neutral-400);
+  background: var(--navy);
+  text-decoration: none;
+  position: relative;
+}
+.video-thumb {
+  width: 100%;
+  background: url('drought-thumb.png') center center / cover no-repeat;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+  overflow: hidden;
+}
+.video-thumb::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: rgba(0,23,45,0.2);
+}
+.video-play-btn {
+  border-radius: 50%;
+  background: rgba(254,254,254,0.9);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1;
+  box-shadow: 0 3px 12px rgba(0,0,0,0.25);
+}
+.video-play-btn svg { margin-left: 3px; }
+.video-bar {
+  display: flex;
+  align-items: center;
+  background: var(--navy);
+}
+.video-bar-icon { flex-shrink: 0; }
+.video-bar-text {
+  font-family: var(--font-sans);
+  color: rgba(254,254,254,0.7);
+}
+.video-bar-text strong { color: var(--neutral-50); font-weight: 600; }
+
+/* Provenance callout */
+.prov-callout {
+  display: flex;
+  align-items: flex-start;
+  background: rgba(0,82,158,0.04);
+  border: 1px solid rgba(0,82,158,0.1);
+  border-radius: 5px;
+}
+.prov-callout svg { flex-shrink: 0; margin-top: 1px; }
+.prov-callout p {
+  font-family: var(--font-sans);
+  color: var(--neutral-900);
+  line-height: 1.5;
+}
+.prov-callout code {
+  font-family: var(--font-mono);
+  color: var(--cable-blue);
+  background: rgba(0,82,158,0.06);
+  padding: 0 3px;
+  border-radius: 2px;
+}
+
+/* Swarm diagram */
+.swarm-diagram svg { width: 100%; height: auto; }
+
+/* User intent bubble */
+.user-intent-bubble {
+  position: relative;
+  background: var(--neutral-200);
+  border: 1px solid var(--neutral-400);
+  border-radius: 12px 12px 12px 2px;
+}
+.user-intent-bubble::before {
+  content: '';
+  position: absolute;
+  bottom: -8px; left: 14px;
+  width: 0; height: 0;
+  border-left: 8px solid var(--neutral-400);
+  border-right: 8px solid transparent;
+  border-top: 8px solid var(--neutral-200);
+  border-bottom: 8px solid transparent;
+}
+.user-intent-label { display: flex; align-items: center; gap: 6px; margin-bottom: 6px; }
+.user-intent-avatar {
+  border-radius: 50%;
+  background: var(--soil);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.user-intent-name {
+  font-family: var(--font-sans);
+  font-weight: 600;
+  color: var(--neutral-700);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+.user-intent-text {
+  font-family: var(--font-sans);
+  font-style: italic;
+  color: var(--navy);
+  line-height: 1.5;
+}
+.user-intent-text em { font-style: normal; font-weight: 600; color: var(--ocean-blue); }
+
+/* Provider table */
+.provider-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-family: var(--font-sans);
+}
+.provider-table th {
+  text-align: left;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--navy);
+  border-bottom: 2px solid var(--neutral-400);
+}
+.provider-table td {
+  border-bottom: 1px solid var(--neutral-400);
+  color: var(--neutral-900);
+}
+.provider-table tr:last-child td { border-bottom: none; }
+.provider-table .prov-name { font-weight: 600; color: var(--ocean-blue); }
+.provider-table .prov-usage {
+  font-family: var(--font-mono);
+  color: var(--cable-blue);
+}
+
+/* Narration chain */
+.narration-chain {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+}
+.nc-pill {
+  font-family: var(--font-mono);
+  font-weight: 600;
+  border-radius: 12px;
+  color: white;
+}
+.nc-arrow { color: var(--neutral-600); }
+
+/* Guard callout */
+.guard-callout {
+  display: flex;
+  align-items: flex-start;
+  background: rgba(26,90,105,0.04);
+  border: 1px solid rgba(26,90,105,0.1);
+  border-radius: 5px;
+}
+.guard-callout svg { flex-shrink: 0; margin-top: 1px; }
+.guard-callout p {
+  font-family: var(--font-sans);
+  color: var(--neutral-900);
+  line-height: 1.5;
+}
+.guard-callout code {
+  font-family: var(--font-mono);
+  color: var(--ocean-blue);
+  background: rgba(26,90,105,0.06);
+  padding: 0 3px;
+  border-radius: 2px;
+}
+
+/* YAML code block */
+.yaml-code {
+  background: var(--neutral-200);
+  border: 1px solid var(--neutral-400);
+  border-radius: 6px;
+  font-family: var(--font-mono);
+  color: var(--neutral-900);
+  white-space: pre;
+  overflow-x: auto;
+  position: relative;
+}
+.yaml-code::after {
+  content: 'yaml';
+  position: absolute;
+  top: 6px; right: 10px;
+  font-family: var(--font-mono);
+  font-weight: 500;
+  color: var(--neutral-600);
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
+}
+.yaml-code .yk { color: var(--ocean-blue); font-weight: 600; }
+.yaml-code .yv { color: var(--cable-blue); }
+.yaml-code .ys { color: var(--leaf-green); }
+.yaml-code .yn { color: var(--olive); font-weight: 600; }
+.yaml-code .yd { color: var(--neutral-600); }
+.yaml-code .yc { color: var(--neutral-600); font-style: italic; }
+
+/* Code zoom (disable web interaction) */
+.code-zoom-wrap { width: 100%; overflow: hidden; position: relative; border-radius: 8px; }
+.code-zoom-inner { transform-origin: top left; }
+
+/* ── Pipeline Table ── */
+.pipeline-details {
+  display: flex;
+  gap: 28px;
+  align-items: flex-start;
+}
+.pipeline-table-wrap { flex: 1; min-width: 0; }
+.pipeline-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-family: var(--font-sans);
+}
+.pipeline-table th {
+  text-align: left;
+  font-weight: 600;
+  color: var(--navy);
+  border-bottom: 2px solid var(--neutral-400);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+.pipeline-table td {
+  border-bottom: 1px solid var(--neutral-400);
+  color: var(--neutral-900);
+  vertical-align: top;
+}
+.pipeline-table tr:last-child td { border-bottom: none; }
+.pipeline-table .stage-num {
+  font-weight: 700;
+  color: var(--cable-blue);
+  text-align: center;
+}
+.pipeline-table .cli-cell {
+  font-family: var(--font-mono);
+  color: var(--cable-blue);
+}
+.pipeline-table .status-impl {
+  color: var(--leaf-green);
+  font-weight: 600;
+}
+.pipeline-table .status-plan {
+  color: var(--neutral-700);
+  font-weight: 500;
+  font-style: italic;
+}
+.pipeline-table .status-partial {
+  color: var(--amber);
+  font-weight: 600;
+}
+
+/* Stream block */
+.stream-block { flex: 1; min-width: 0; }
+.stream-label {
+  font-family: var(--font-sans);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  color: var(--ocean-blue);
+}
+.stream-code {
+  background: var(--neutral-200);
+  border: 1px solid var(--neutral-400);
+  border-radius: 6px;
+  font-family: var(--font-mono);
+  color: var(--neutral-900);
+  line-height: 1.6;
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+.stream-code .sc-cmd { color: var(--cable-blue); font-weight: 600; }
+.stream-code .sc-pipe { color: var(--leaf-green); font-weight: 700; }
+.stream-code .sc-flag { color: var(--ocean-blue); }
+.stream-note {
+  font-family: var(--font-sans);
+  color: var(--neutral-700);
+  line-height: 1.5;
+}
+
+/* ── Features ── */
+.features-card {
+  background: var(--neutral-200);
+  border: 1px solid var(--neutral-400);
+  border-radius: 6px;
+}
+.features-card h3 {
+  font-family: var(--font-sans);
+  font-weight: 700;
+  color: var(--navy);
+}
+.feat-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+}
+.feat-list li {
+  display: flex;
+  align-items: flex-start;
+  font-family: var(--font-sans);
+  color: var(--neutral-900);
+  line-height: 1.5;
+}
+.feat-dot {
+  border-radius: 50%;
+  background: var(--seafoam);
+  flex-shrink: 0;
+}
+.feat-list li strong { color: var(--ocean-blue); font-weight: 700; }
+.feat-list li code {
+  font-family: var(--font-mono);
+  color: var(--cable-blue);
+  background: rgba(0,82,158,0.06);
+  padding: 0 3px;
+  border-radius: 2px;
+}
+.feat-meta {
+  border-top: 1px solid var(--neutral-400);
+  display: flex;
+  flex-wrap: wrap;
+}
+.feat-meta-pill {
+  font-family: var(--font-sans);
+  font-weight: 700;
+  color: var(--navy);
+  background: var(--neutral-50);
+  border: 1px solid var(--neutral-400);
+}
+.feature-pills { display: flex; flex-wrap: wrap; }
+.feat-pill {
+  display: inline-flex;
+  align-items: center;
+  font-family: var(--font-sans);
+  font-weight: 600;
+  background: var(--neutral-200);
+  border: 1px solid var(--neutral-400);
+  color: var(--navy);
+}
+.feat-pill svg { flex-shrink: 0; }
+
+/* ── Foundation ── */
+.foundation-section {
+  position: relative;
+  overflow: hidden;
+  background: linear-gradient(175deg, var(--neutral-50) 0%, var(--neutral-200) 100%);
+}
+.foundation-section::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(ellipse 600px 400px at 85% 60%, rgba(26,90,105,0.04), transparent),
+    radial-gradient(ellipse 500px 350px at 15% 40%, rgba(0,82,158,0.03), transparent);
+  pointer-events: none;
+}
+.foundation-heading {
+  font-family: var(--font-sans);
+  font-weight: 700;
+  color: var(--navy);
+  line-height: 1.25;
+  position: relative;
+}
+.foundation-sub {
+  font-family: var(--font-sans);
+  color: var(--neutral-700);
+  position: relative;
+}
+.foundation-layers {
+  display: flex;
+  position: relative;
+}
+.foundation-pyramid {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+  z-index: 2;
+}
+.foundation-col {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  position: relative;
+  z-index: 2;
+}
+.foundation-layer-card {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+.foundation-layer-card .flc-number {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  font-family: var(--font-sans);
+  font-weight: 700;
+  color: white;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.12);
+}
+.foundation-layer-card .flc-title {
+  font-family: var(--font-sans);
+  font-weight: 700;
+  line-height: 1.3;
+}
+.foundation-layer-card .flc-abbrev {
+  font-family: var(--font-mono);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.8px;
+}
+.foundation-layer-card .flc-desc {
+  font-family: var(--font-sans);
+  line-height: 1.55;
+  color: var(--neutral-900);
+}
+.foundation-layer-card .flc-desc code {
+  font-family: var(--font-mono);
+  padding: 0 3px;
+  border-radius: 2px;
+}
+.foundation-connector {
+  position: absolute;
+  z-index: 1;
+  pointer-events: none;
+}
+
+/* Layer-specific coloring */
+.flc-cli .flc-number { background: linear-gradient(135deg, var(--leaf-green), #1a4a08); }
+.flc-cli .flc-title  { color: var(--leaf-green); }
+.flc-cli .flc-abbrev { color: var(--leaf-green); }
+.flc-cli .flc-desc code { color: var(--leaf-green); background: rgba(44,103,12,0.08); }
+
+.flc-api .flc-number { background: linear-gradient(135deg, var(--cable-blue), #003d7a); }
+.flc-api .flc-title  { color: var(--cable-blue); }
+.flc-api .flc-abbrev { color: var(--cable-blue); }
+.flc-api .flc-desc code { color: var(--cable-blue); background: rgba(0,82,158,0.08); }
+
+.flc-mcp .flc-number { background: linear-gradient(135deg, var(--ocean-blue), #0e3d4a); }
+.flc-mcp .flc-title  { color: var(--ocean-blue); }
+.flc-mcp .flc-abbrev { color: var(--ocean-blue); }
+.flc-mcp .flc-desc code { color: var(--ocean-blue); background: rgba(26,90,105,0.08); }
+
+/* Highlight cards */
+.foundation-highlight-card {
+  display: flex;
+  align-items: flex-start;
+  background: var(--neutral-50);
+  border: 1px solid var(--neutral-400);
+  border-top: 3px solid var(--neutral-400);
+}
+.foundation-highlight-card .fhc-icon {
+  flex-shrink: 0;
+  border-radius: 6px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.foundation-highlight-card .fhc-text {
+  font-family: var(--font-sans);
+  color: var(--neutral-900);
+}
+.foundation-highlight-card .fhc-text strong {
+  font-weight: 700;
+  display: block;
+  margin-bottom: 2px;
+}
+.foundation-highlight-card .fhc-text code {
+  font-family: var(--font-mono);
+  padding: 0 3px;
+  border-radius: 2px;
+}
+.fhc-cli { border-top-color: var(--leaf-green); }
+.fhc-cli .fhc-icon { background: rgba(44,103,12,0.08); }
+.fhc-cli .fhc-icon svg { color: var(--leaf-green); }
+.fhc-cli .fhc-text strong { color: var(--leaf-green); }
+.fhc-cli .fhc-text code { color: var(--leaf-green); background: rgba(44,103,12,0.06); }
+
+.fhc-api { border-top-color: var(--cable-blue); }
+.fhc-api .fhc-icon { background: rgba(0,82,158,0.08); }
+.fhc-api .fhc-icon svg { color: var(--cable-blue); }
+.fhc-api .fhc-text strong { color: var(--cable-blue); }
+.fhc-api .fhc-text code { color: var(--cable-blue); background: rgba(0,82,158,0.06); }
+
+.fhc-mcp { border-top-color: var(--ocean-blue); }
+.fhc-mcp .fhc-icon { background: rgba(26,90,105,0.08); }
+.fhc-mcp .fhc-icon svg { color: var(--ocean-blue); }
+.fhc-mcp .fhc-text strong { color: var(--ocean-blue); }
+.fhc-mcp .fhc-text code { color: var(--ocean-blue); background: rgba(26,90,105,0.06); }
+
+.fhc-fast { border-top-color: var(--amber); }
+.fhc-fast .fhc-icon { background: rgba(255,193,7,0.12); }
+.fhc-fast .fhc-icon svg { color: var(--soil); }
+.fhc-fast .fhc-text strong { color: var(--soil); }
+.fhc-fast .fhc-text code { color: var(--soil); background: rgba(80,69,44,0.06); }
+
+/* ── Get Started Footer ── */
+.get-started-footer {
+  background: linear-gradient(135deg, var(--navy) 0%, var(--deep-teal) 100%);
+  position: relative;
+  overflow: hidden;
+}
+.get-started-footer::before {
+  content: '';
+  position: absolute;
+  top: -50px; right: -10px;
+  width: 200px; height: 200px;
+  background: radial-gradient(circle, rgba(95,157,174,0.15), transparent 70%);
+  border-radius: 50%;
+  pointer-events: none;
+}
+.get-started-footer::after {
+  content: '';
+  position: absolute;
+  bottom: -40px; left: 180px;
+  width: 160px; height: 160px;
+  background: radial-gradient(circle, rgba(0,82,158,0.12), transparent 70%);
+  border-radius: 50%;
+  pointer-events: none;
+}
+.gs-main { flex: 1 1 auto; min-width: 0; z-index: 1; }
+.gs-heading {
+  font-family: var(--font-sans);
+  font-weight: 700;
+  color: var(--neutral-50);
+  letter-spacing: -0.3px;
+}
+.gs-code {
+  background: rgba(254,254,254,0.07);
+  border: 1px solid rgba(254,254,254,0.1);
+  border-radius: 8px;
+  font-family: var(--font-mono);
+  white-space: pre;
+  color: #cbd5e1;
+}
+.gs-code .gs-cmd { color: #7dd3fc; font-weight: 500; }
+.gs-code .gs-dim { color: #64748b; }
+.gs-links {
+  display: flex;
+  flex-wrap: wrap;
+  z-index: 1;
+}
+.gs-link-item { text-align: center; }
+.gs-link-label {
+  font-family: var(--font-sans);
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  color: var(--seafoam);
+  margin-bottom: 2px;
+}
+.gs-link-url {
+  font-family: var(--font-sans);
+  color: rgba(254,254,254,0.6);
+}
+.gs-qr { flex-shrink: 0; z-index: 1; text-align: center; }
+.gs-qr-box {
+  background: white;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 3px 12px rgba(0,0,0,0.2);
+  overflow: hidden;
+}
+.gs-qr-label {
+  font-family: var(--font-sans);
+  color: rgba(254,254,254,0.5);
+  letter-spacing: 0.3px;
+}
+
+
+/* ═══════════════════════════════════════════
+   PART 3 — PRINT LAYOUT OVERRIDES
+   Grid, sizing, dimensions for 14400×10800px
+   ═══════════════════════════════════════════ */
+
+/* ── POSTER GRID ── */
+.poster {
+  width: 14400px;
+  max-width: 14400px;
+  height: 10800px;
+  overflow: hidden;
+  display: grid;
+  grid-template-columns: repeat(12, 1fr);
+  grid-template-rows: 1200px 2200px 2600px 3100px 1700px;
+  grid-template-areas:
+    "hd hd hd hd hd hd hd hd hd hd hd hd"
+    "ch ch ch pp pp pp pp pp pp pp pp pp"
+    "ft ft ft ft rp rp rp fn fn fn fn fn"
+    "na na na dr dr dr dr dr hr hr hr hr"
+    "na na na dr dr dr dr dr gs gs gs gs";
+  gap: 0;
+  box-shadow: none;
+}
+
+
+/* ── Hide web-only elements ── */
+.challenge-transition,
+.poster-bottom-pad,
+.flow-cue,
+.pipeline-lightbox,
+.code-lightbox,
+.print-mode-toggle,
+.gallery-section      { display: none; }
+
+
+/* ── Grid area assignments ── */
+.header              { grid-area: hd; }
+.challenge-section   { grid-area: ch; }
+.pipeline-section    { grid-area: pp; }
+.foundation-section  { grid-area: fn; }
+
+/* Features wrapper -> display:contents so children become grid items */
+.features-section                       { display: contents; }
+.features-section > .features-card:first-child { grid-area: ft; }
+.features-section > .features-card:last-child  { display: contents; }
+.get-started-footer                     { grid-area: gs; }
+
+/* Use-case row wrappers -> display:contents */
+#uc-row-45 { display: contents; }
+#uc-row-67 { display: contents; }
+/* HRRR = uc-row-45 first-child,  Drought = uc-row-45 last-child */
+#uc-row-45 > .usecase-card:first-child { grid-area: hr; }
+#uc-row-45 > .usecase-card:last-child  { grid-area: dr; }
+/* AI Narration = uc-row-67 first-child,  Repro Pipelines = uc-row-67 last-child */
+#uc-row-67 > .usecase-card:first-child { grid-area: na; }
+#uc-row-67 > .usecase-card:last-child  { grid-area: rp; }
+
+
+/* ── Shared: Section borders ── */
+.challenge-section,
+.pipeline-section,
+.foundation-section,
+.usecase-card,
+.features-section > .features-card:first-child {
+  border: 4px solid var(--neutral-400);
+  background: var(--neutral-50);
+}
+.get-started-footer {
+  border: 4px solid var(--neutral-600);
+}
+.usecase-card {
+  border-left: 14px solid var(--cable-blue);
+}
+
+
+/* ── Shared: Section tag ── */
+.section-tag { margin-bottom: 30px; }
+.section-tag span { font-size: 67px; letter-spacing: 8px; }
+.section-tag .diamond { width: 54px; height: 54px; }
+
+
+/* ═══════════════════════════════════════════
+   ROW 1 — HEADER (14400 x 1200)
+   ═══════════════════════════════════════════ */
+.header { overflow: hidden; }
+.header::after { height: 12px; }
+.header-content { min-height: 0; height: 1200px; }
+.header-left { display: none; }
+.header-right {
+  padding: 36px 300px;
+  align-items: stretch;
+  text-align: center;
+  background: radial-gradient(
+    ellipse at center 60%,
+    rgba(247,245,238,0.92) 0%,
+    rgba(247,245,238,0.75) 50%,
+    rgba(247,245,238,0.35) 100%
+  );
+}
+.header-dataviz { display: block; }
+.project-name    { font-size: 250px; margin-bottom: 0; line-height: 1.0; }
+.poster-title    { font-size: 150px; margin-bottom: 12px; line-height: 1.15; }
+.poster-subtitle { font-size: 100px; margin-bottom: 18px; }
+.author-block    { margin-bottom: 18px; gap: 12px; }
+.author-name     { font-size: 100px; }
+.author-org      { font-size: 83px; }
+.author-orcid    { font-size: 67px; }
+.orcid-dot       { font-size: 36px; width: 67px; height: 67px; }
+.badges          { gap: 48px; }
+.badge           { font-size: 54px; padding: 18px 48px 18px 18px; gap: 21px; border-radius: 36px; }
+.badge-pip       { width: 96px; height: 96px; font-size: 42px; border-radius: 28px; }
+.badge-pip svg   { width: 48px; height: 48px; }
+.badge-label     { font-size: 48px; }
+.badge-value     { font-size: 54px; }
+
+
+/* ═══════════════════════════════════════════
+   ROW 2A — CHALLENGE (3600 x 2200)
+   Row layout: text left (~55%), graphic right (~45%)
+   ═══════════════════════════════════════════ */
+.challenge-section {
+  padding: 60px;
+  overflow: hidden;
+  display: flex; flex-direction: column;
+}
+.challenge-card {
+  padding: 60px;
+  flex: 1;
+  overflow: hidden;
+  border-radius: 36px;
+  display: flex; flex-direction: column;
+}
+.challenge-frame { display: none; }
+.challenge-inner {
+  display: flex;
+  flex-direction: row;
+  gap: 60px;
+  padding: 0;
+  flex: 1;
+  align-items: stretch;
+}
+.challenge-text {
+  flex: 1 1 65%;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+}
+.challenge-heading { font-size: 120px; margin-bottom: 24px; }
+.challenge-body p  { font-size: 66px; line-height: 1.4; margin-bottom: 20px; }
+.challenge-body .tok { font-size: 58px; padding: 8px 24px; border-radius: 14px; }
+.challenge-body .em-bold { font-size: 66px; }
+.challenge-graphic {
+  flex: 0 0 30%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  max-width: none;
+}
+.challenge-graphic svg {
+  width: 100%;
+  height: auto;
+  max-width: none;
+  max-height: 100%;
+}
+
+
+/* ═══════════════════════════════════════════
+   ROW 2B — PIPELINE (10800 x 2200)
+   Grid layout: visual left, stage table right.
+   ═══════════════════════════════════════════ */
+.pipeline-section {
+  padding: 60px 72px;
+  overflow: hidden;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  grid-template-rows: auto auto auto 1fr auto;
+  column-gap: 84px;
+}
+/* Heading elements span full width */
+.pipeline-section .section-tag { grid-column: 1 / -1; grid-row: 1; }
+.pipeline-heading { font-size: 150px; margin-bottom: 18px; grid-column: 1 / -1; grid-row: 2; }
+.pipeline-sub     { font-size: 83px; margin-bottom: 24px; grid-column: 1 / -1; grid-row: 3; }
+
+/* Visual on the left — zoom 3.2 (1440×3.2 = 4608w × 1664h) */
+.pipeline-visual-wrap {
+  grid-column: 1;
+  grid-row: 4 / 6;
+  cursor: default;
+  border: none;
+  background: transparent;
+  overflow: hidden;
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+}
+.pipeline-visual-wrap .zoom-hint { display: none; }
+.pipeline-visual {
+  width: 1440px;
+  height: 520px;
+  min-height: 0;
+  transform: none;
+  zoom: 3.2;
+  flex-shrink: 0;
+}
+/* Hide animated dots — meaningless on static poster, CSS zoom misaligns them */
+.pipeline-visual .flow-bg circle[r="3.5"],
+.pipeline-visual .flow-bg circle[r="3"] { display: none; }
+
+.phase-label     { font-size: 14px; }
+.stage-circle    { width: 66px; height: 66px; }
+.stage-circle svg { width: 34px; height: 34px; }
+.stage-label-txt { font-size: 14px; }
+.stage-cli-txt   { font-size: 11px; }
+.source-icon     { width: 48px; height: 48px; }
+.source-icon svg { width: 32px; height: 32px; }
+.source-label    { font-size: 14px; }
+.callout         { display: block; }
+.callout-title   { font-size: 12px; }
+.callout-text    { font-size: 11px; line-height: 1.35; }
+.ct-tag          { font-size: 10px; padding: 3px 8px; }
+.format-pills    { display: flex; }
+.fpill           { font-size: 11px; padding: 4px 10px; border-radius: 6px; }
+.phase-summaries { display: flex; }
+.phase-summary   { font-size: 11px; line-height: 1.35; }
+
+/* Stage table + stream: children promoted to grid via display:contents */
+.pipeline-details {
+  display: contents;
+}
+.pipeline-table-wrap { grid-column: 2; grid-row: 4; align-self: start; }
+.pipeline-table    { font-size: 54px; }
+.pipeline-table th { font-size: 44px; padding: 20px 30px; }
+.pipeline-table td { padding: 20px 30px; }
+.pipeline-table .stage-num { width: 90px; }
+.pipeline-table .cli-cell  { font-size: 48px; }
+.pipeline-table .status-impl,
+.pipeline-table .status-plan,
+.pipeline-table .status-partial { font-size: 48px; }
+
+/* Streaming example — own grid row, right column */
+.stream-block { grid-column: 2; grid-row: 5; min-width: 0; align-self: end; }
+.stream-label { font-size: 44px; margin-bottom: 14px; }
+.stream-code  { font-size: 40px; padding: 28px 36px; border-radius: 20px; line-height: 1.5; white-space: pre-wrap; word-break: break-all; }
+.stream-note  { font-size: 40px; margin-top: 14px; line-height: 1.4; }
+.stream-note code { font-size: 40px; }
+
+
+/* ═══════════════════════════════════════════
+   ROW 3A — KEY FEATURES (4800 x 2600)
+   ═══════════════════════════════════════════ */
+.features-section > .features-card:first-child {
+  padding: 84px 60px 84px 84px;
+  overflow: hidden;
+  display: flex; flex-direction: column;
+  justify-content: space-between;
+}
+.features-card { border-radius: 36px; }
+.features-card h3 { font-size: 150px; margin-bottom: 48px; }
+.feat-list      { gap: 48px; flex: 1; }
+.feat-list li   { font-size: 83px; line-height: 1.45; gap: 42px; }
+.feat-dot       { width: 42px; height: 42px; margin-top: 22px; }
+.feat-list li strong { font-size: 83px; }
+.feat-list li code   { font-size: 75px; }
+.feat-meta       { margin-top: 48px; padding-top: 48px; gap: 30px; }
+.feat-meta-pill  { font-size: 67px; padding: 15px 42px; border-radius: 28px; }
+.feature-pills   { gap: 30px; margin-top: 30px; }
+.feat-pill       { font-size: 63px; padding: 18px 42px; gap: 18px; border-radius: 30px; }
+.feat-pill svg   { width: 63px; height: 63px; }
+
+
+/* ═══════════════════════════════════════════
+   ROW 3B — REPRODUCIBLE PIPELINE CONFIGS
+   (3600 x 2600, use-case card)
+   ═══════════════════════════════════════════ */
+#uc-row-67 > .usecase-card:last-child { padding: 60px 72px; }
+#uc-row-67 > .usecase-card:last-child .usecase-heading { font-size: 100px; margin-bottom: 18px; }
+#uc-row-67 > .usecase-card:last-child .usecase-desc    { font-size: 67px; margin-bottom: 24px; }
+#uc-row-67 > .usecase-card:last-child .yaml-code       { font-size: 44px; padding: 30px 48px; flex: 1; line-height: 1.35; margin-bottom: 24px; }
+#uc-row-67 > .usecase-card:last-child .yaml-code::after { font-size: 36px; }
+#uc-row-67 > .usecase-card:last-child .usecase-code    { font-size: 48px; padding: 30px 48px; line-height: 1.4; }
+#uc-row-67 > .usecase-card:last-child .usecase-code::after { font-size: 36px; }
+#uc-row-67 > .usecase-card:last-child .feature-pills   { gap: 18px; margin-top: 18px; }
+#uc-row-67 > .usecase-card:last-child .feat-pill       { font-size: 42px; padding: 12px 24px; }
+
+
+/* ═══════════════════════════════════════════
+   ROW 3C — FOUNDATION (6000 x 2600)
+   50/50 split: descriptions left, pyramid right.
+   ═══════════════════════════════════════════ */
+.foundation-section {
+  padding: 60px 60px 48px 48px;
+  overflow: hidden;
+  display: flex; flex-direction: column;
+}
+.foundation-heading { font-size: 110px; margin-bottom: 20px; }
+.foundation-sub     { font-size: 67px; margin-bottom: 24px; line-height: 1.4; }
+.foundation-layers {
+  gap: 36px;
+  flex-direction: row;
+  flex-wrap: nowrap;
+  align-items: stretch;
+  flex: 1;
+  min-height: 0;
+}
+.foundation-pyramid {
+  flex: 1 1 50%;
+  padding: 0;
+  order: 2;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.foundation-pyramid svg { width: auto; height: 1600px; }
+.foundation-col {
+  flex-direction: column;
+  gap: 18px;
+  flex-wrap: nowrap;
+  flex: 1 1 50%;
+  justify-content: center;
+  min-width: 0;
+}
+.foundation-col.col-left  { padding-right: 0; text-align: right; order: 1; }
+.foundation-col.col-right { display: none; }
+.foundation-layer-card {
+  padding: 20px 30px;
+  border-radius: 20px;
+  text-align: right;
+  flex: 0 0 auto;
+}
+.foundation-layer-card .flc-number { width: 54px; height: 54px; font-size: 28px; margin-bottom: 8px; }
+.foundation-layer-card .flc-title  { font-size: 46px; margin-bottom: 6px; }
+.foundation-layer-card .flc-abbrev { font-size: 36px; margin-bottom: 6px; }
+.foundation-layer-card .flc-desc   { font-size: 38px; line-height: 1.3; }
+.foundation-layer-card .flc-desc code { font-size: 34px; }
+.foundation-highlights {
+  display: flex;
+  gap: 24px;
+  margin-top: 24px;
+  flex: 0 0 auto;
+}
+.foundation-highlight-card { flex: 1 1 0; padding: 30px 36px; border-radius: 24px; }
+.foundation-highlight-card .fhc-icon     { width: 84px; height: 84px; }
+.foundation-highlight-card .fhc-icon svg { width: 48px; height: 48px; }
+.foundation-highlight-card .fhc-text        { font-size: 42px; line-height: 1.35; }
+.foundation-highlight-card .fhc-text strong { font-size: 46px; }
+.foundation-highlight-card .fhc-text code   { font-size: 40px; }
+
+
+/* ═══════════════════════════════════════════
+   ROWS 4-5 — USE CASE CARDS (shared)
+   ═══════════════════════════════════════════ */
+.usecase-card {
+  padding: 96px;
+  overflow: hidden;
+  margin: 0;
+  border-radius: 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+}
+.usecase-heading { font-size: 150px; margin-bottom: 36px; }
+.usecase-desc    { font-size: 100px; line-height: 1.45; margin-bottom: 54px; }
+.usecase-code    { font-size: 83px; padding: 54px 72px; line-height: 1.5; border-radius: 30px; }
+.usecase-code::after { font-size: 63px; top: 42px; right: 48px; }
+
+/* Code steps */
+.code-steps    { gap: 14px; flex: 0 0 auto; }
+.code-step     { padding: 36px 60px; }
+.step-dot      { width: 120px; height: 120px; font-size: 54px; border-radius: 30px; }
+.step-dot svg  { width: 67px; height: 67px; }
+.step-code     { font-size: 70px; line-height: 1.4; }
+.step-stage-tag { font-size: 54px; padding: 12px 30px; border-radius: 18px; }
+
+/* DAG diagram */
+.dag-wrap       { margin-bottom: 42px; gap: 21px; }
+.dag-box        { padding: 42px 54px; font-size: 75px; border-radius: 28px; gap: 36px; }
+.dag-box svg    { width: 92px; height: 92px; }
+.dag-stage-tag  { font-size: 67px; min-width: 400px; padding: 15px 36px; border-radius: 21px; }
+.dag-arrow      { padding: 12px 0; }
+.dag-arrow svg  { width: 83px; height: 83px; }
+
+/* Placeholders & captions */
+.usecase-image-wrap      { flex: 1 1 auto; min-height: 0; border-radius: 30px; display: flex; flex-direction: column; }
+.usecase-placeholder     { flex: 1 1 auto; min-height: 300px; border-radius: 30px; }
+.usecase-placeholder svg { transform: scale(3); }
+.usecase-placeholder span { font-size: 75px; }
+.usecase-caption      { font-size: 75px; margin-top: 30px; flex: 0 0 auto; }
+.usecase-caption code { font-size: 67px; }
+
+/* Flow connectors */
+.flow-connector     { padding: 21px 0; }
+.flow-connector svg { width: 83px; height: 96px; }
+
+/* Video preview (Drought) */
+.video-preview       { margin-bottom: 30px; border-radius: 30px; overflow: hidden; flex: 1 1 auto; min-height: 0; display: flex; flex-direction: column; }
+.video-thumb         { flex: 1 1 auto; min-height: 400px; }
+.video-play-btn      { width: 225px; height: 225px; }
+.video-play-btn svg  { width: 83px; height: 83px; }
+.video-bar           { padding: 36px 54px; gap: 48px; flex: 0 0 auto; }
+.video-bar-icon      { width: 92px; height: 92px; }
+.video-bar-text      { font-size: 75px; }
+
+/* Provenance callout */
+.prov-callout      { padding: 48px 63px; margin-top: 0; gap: 48px; border-radius: 28px; flex: 0 0 auto; }
+.prov-callout svg  { width: 83px; height: 83px; }
+.prov-callout p    { font-size: 75px; line-height: 1.45; }
+.prov-callout code { font-size: 67px; }
+
+/* ── AI Narration card (3 cols × 2 rows = narrow & tall) ── */
+#uc-row-67 > .usecase-card:first-child {
+  border-left-color: var(--ocean-blue);
+  padding: 72px 72px 54px;
+}
+#uc-row-67 > .usecase-card:first-child .usecase-heading { font-size: 110px; margin-bottom: 18px; }
+#uc-row-67 > .usecase-card:first-child .usecase-desc    { font-size: 67px; margin-bottom: 30px; }
+
+/* User intent bubble */
+.user-intent-bubble { padding: 36px 48px; margin-bottom: 30px; border-radius: 30px; }
+.user-intent-bubble::before { display: none; }
+.user-intent-avatar     { width: 84px; height: 84px; }
+.user-intent-avatar svg { width: 48px; height: 48px; }
+.user-intent-name { font-size: 48px; }
+.user-intent-text { font-size: 58px; line-height: 1.4; }
+
+/* Swarm diagram — sized to leave room for bottom content */
+.swarm-diagram     { margin-bottom: 24px; flex: 0 0 auto; display: flex; align-items: center; justify-content: center; }
+.swarm-diagram svg { height: 1600px; width: auto; }
+
+/* Narration chain */
+.narration-chain { margin-top: 24px; gap: 18px; }
+.nc-pill  { font-size: 48px; padding: 16px 36px; border-radius: 30px; }
+.nc-arrow { font-size: 54px; }
+
+/* Guard callout */
+.guard-callout      { padding: 30px 42px; margin-top: 24px; border-radius: 24px; gap: 30px; }
+.guard-callout svg  { width: 60px; height: 60px; }
+.guard-callout p    { font-size: 50px; line-height: 1.4; }
+.guard-callout code { font-size: 46px; }
+
+/* Section labels inside narration card */
+#uc-row-67 > .usecase-card:first-child > div[style*="text-transform"] {
+  font-size: 42px !important;
+  margin-top: 24px !important;
+  margin-bottom: 12px !important;
+}
+
+/* Code blocks in narration card (override inline styles) */
+#uc-row-67 > .usecase-card:first-child .usecase-code {
+  font-size: 42px !important;
+  padding: 30px 42px !important;
+  line-height: 1.4 !important;
+  border-radius: 24px;
+  margin-bottom: 12px !important;
+}
+#uc-row-67 > .usecase-card:first-child .usecase-code::after { font-size: 30px; }
+
+/* Provider table (AI Narration) */
+.provider-table-wrap { margin-top: 24px; margin-bottom: 24px; }
+.provider-table    { font-size: 50px; border-radius: 24px; }
+.provider-table th { font-size: 42px; padding: 24px 36px; }
+.provider-table td { padding: 24px 36px; }
+.prov-name  { font-size: 50px; }
+.prov-usage { font-size: 42px; }
+
+/* YAML code (Repro Pipelines) */
+.yaml-code { font-size: 75px; padding: 54px 72px; line-height: 1.45; margin-bottom: 42px; border-radius: 30px; }
+.yaml-code::after { font-size: 58px; }
+
+/* Code zoom (disable web interaction) */
+.code-zoom-wrap { cursor: default; overflow: visible; height: auto; }
+.code-zoom-wrap .zoom-hint { display: none; }
+.code-zoom-inner { transform: none; }
+
+
+/* ═══════════════════════════════════════════
+   ROW 5 — GET STARTED (4800 x 1700)
+   ═══════════════════════════════════════════ */
+.get-started-footer {
+  margin: 0;
+  padding: 72px 84px;
+  gap: 54px;
+  border-radius: 0;
+  display: flex;
+  align-items: flex-start;
+  flex-direction: column;
+  justify-content: space-between;
+}
+.get-started-footer::before,
+.get-started-footer::after { display: none; }
+.get-started-footer .code-zoom-wrap { display: contents; }
+.get-started-footer .code-zoom-inner {
+  display: flex; gap: 84px; align-items: flex-start; width: 100%;
+}
+.get-started-footer .gs-heading { font-size: 133px; margin-bottom: 42px; color: var(--neutral-50); }
+.gs-code       { font-size: 83px; padding: 54px 72px; margin-bottom: 48px; line-height: 1.5; border-radius: 30px; }
+.gs-cmd        { font-size: 83px; }
+.gs-dim        { font-size: 75px; }
+.gs-links           { gap: 24px; flex-wrap: wrap; }
+.gs-badge           { padding: 18px 42px 18px 18px; border-radius: 48px; gap: 18px;
+                      text-decoration: none; color: var(--neutral-50);
+                      background: rgba(254,254,254,0.08); border: 3px solid rgba(254,254,254,0.18); }
+.gs-badge-pip       { width: 63px; height: 63px; border-radius: 16px; }
+.gs-badge-pip svg   { width: 36px; height: 36px; }
+.gs-badge-pip.pip-pypi   { font-size: 30px; }
+.gs-badge-pip.pip-doi    { font-size: 30px; }
+.gs-badge-pip.pip-gh     { background: var(--neutral-900); }
+.gs-badge-pip.pip-docs   { background: var(--ocean-blue); }
+.gs-badge-pip.pip-assist { background: var(--seafoam); }
+.gs-badge-label     { font-size: 42px; color: rgba(254,254,254,0.55); }
+.gs-badge-value     { font-size: 54px; font-weight: 600; color: var(--neutral-50); }
+.gs-qr         { display: flex; flex-direction: column; align-items: center; }
+.gs-qr-box     { width: 540px; height: 540px; border-radius: 42px; }
+.gs-qr-box img { width: 460px; height: 460px; }
+.gs-qr-label   { font-size: 63px; }
+
+
+/* ═══════════════════════════════════════════
+   PRINT MEDIA — for actual printing
+   ═══════════════════════════════════════════ */
+@media print {
+  body   { background: none; padding: 0; margin: 0; }
+  .poster { box-shadow: none; }
+}
+
+</style>
+</head>
+<body>
+<div class="poster">
+
+  <!-- ════════════ SECTION 1: HEADER ════════════ -->
+
+  <div class="header">
+
+<div class="header-content">
+
+  <!-- Left: full tree illustration, contained (not cropped) -->
+  <div class="header-left">
+    <img src="light-slide-background.png" alt="Illustrated tree with roots transitioning to ethernet cables underground">
+  </div>
+
+  <!-- Right: text with data-viz textures -->
+  <div class="header-right">
+
+    <!-- Data-viz texture background -->
+    <div class="header-dataviz">
+      <svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none">
+        <defs>
+          <pattern id="dotgrid" x="0" y="0" width="28" height="28" patternUnits="userSpaceOnUse">
+            <circle cx="14" cy="14" r="1" fill="#1A5A69" opacity="0.07"/>
+          </pattern>
+          <pattern id="contour" x="0" y="0" width="360" height="360" patternUnits="userSpaceOnUse">
+            <ellipse cx="180" cy="180" rx="160" ry="105" fill="none" stroke="#1A5A69" stroke-width="0.6" opacity="0.06"/>
+            <ellipse cx="180" cy="180" rx="120" ry="78" fill="none" stroke="#1A5A69" stroke-width="0.5" opacity="0.05"/>
+            <ellipse cx="180" cy="180" rx="80" ry="50" fill="none" stroke="#1A5A69" stroke-width="0.45" opacity="0.045"/>
+            <ellipse cx="180" cy="180" rx="42" ry="25" fill="none" stroke="#1A5A69" stroke-width="0.4" opacity="0.04"/>
+          </pattern>
+          <pattern id="hashmarks" x="0" y="0" width="60" height="60" patternUnits="userSpaceOnUse">
+            <line x1="0" y1="0" x2="0" y2="3" stroke="#00529E" stroke-width="0.5" opacity="0.05"/>
+            <line x1="0" y1="0" x2="3" y2="0" stroke="#00529E" stroke-width="0.5" opacity="0.05"/>
+          </pattern>
+        </defs>
+
+        <rect width="100%" height="100%" fill="url(#contour)"/>
+        <rect width="100%" height="100%" fill="url(#dotgrid)"/>
+        <rect width="100%" height="100%" fill="url(#hashmarks)"/>
+
+        <!-- Freeform contour lines -->
+        <path d="M20,60 Q140,30 280,55 Q420,85 540,50 Q680,15 820,45" fill="none" stroke="#5F9DAE" stroke-width="0.7" opacity="0.045"/>
+        <path d="M10,100 Q150,70 300,95 Q440,125 560,90 Q700,55 840,80" fill="none" stroke="#5F9DAE" stroke-width="0.6" opacity="0.04"/>
+        <path d="M30,150 Q160,125 300,145 Q430,170 570,135 Q710,100 850,125" fill="none" stroke="#5F9DAE" stroke-width="0.5" opacity="0.035"/>
+
+        <path d="M40,340 Q180,315 320,335 Q460,360 580,325 Q720,290 860,315" fill="none" stroke="#1A5A69" stroke-width="0.6" opacity="0.035"/>
+        <path d="M50,375 Q190,350 340,370 Q470,395 600,358 Q740,320 880,345" fill="none" stroke="#1A5A69" stroke-width="0.5" opacity="0.03"/>
+
+        <!-- Weather station markers -->
+        <circle cx="200" cy="80" r="2.5" fill="none" stroke="#00529E" stroke-width="0.6" opacity="0.055"/>
+        <line x1="200" y1="76" x2="200" y2="84" stroke="#00529E" stroke-width="0.4" opacity="0.045"/>
+        <line x1="196" y1="80" x2="204" y2="80" stroke="#00529E" stroke-width="0.4" opacity="0.045"/>
+
+        <circle cx="550" cy="140" r="2.5" fill="none" stroke="#00529E" stroke-width="0.6" opacity="0.055"/>
+        <line x1="550" y1="136" x2="550" y2="144" stroke="#00529E" stroke-width="0.4" opacity="0.045"/>
+        <line x1="546" y1="140" x2="554" y2="140" stroke="#00529E" stroke-width="0.4" opacity="0.045"/>
+
+        <circle cx="380" cy="310" r="2.5" fill="none" stroke="#00529E" stroke-width="0.6" opacity="0.05"/>
+        <line x1="380" y1="306" x2="380" y2="314" stroke="#00529E" stroke-width="0.4" opacity="0.04"/>
+        <line x1="376" y1="310" x2="384" y2="310" stroke="#00529E" stroke-width="0.4" opacity="0.04"/>
+
+        <circle cx="720" cy="260" r="2.5" fill="none" stroke="#00529E" stroke-width="0.6" opacity="0.05"/>
+        <line x1="720" y1="256" x2="720" y2="264" stroke="#00529E" stroke-width="0.4" opacity="0.04"/>
+        <line x1="716" y1="260" x2="724" y2="260" stroke="#00529E" stroke-width="0.4" opacity="0.04"/>
+
+        <!-- Faint lat/lon dashes -->
+        <line x1="250" y1="0" x2="250" y2="480" stroke="#1A5A69" stroke-width="0.3" opacity="0.02" stroke-dasharray="4 14"/>
+        <line x1="550" y1="0" x2="550" y2="480" stroke="#1A5A69" stroke-width="0.3" opacity="0.02" stroke-dasharray="4 14"/>
+        <line x1="0" y1="160" x2="900" y2="160" stroke="#1A5A69" stroke-width="0.3" opacity="0.018" stroke-dasharray="4 14"/>
+        <line x1="0" y1="320" x2="900" y2="320" stroke="#1A5A69" stroke-width="0.3" opacity="0.018" stroke-dasharray="4 14"/>
+      </svg>
+    </div>
+
+    <div class="project-name">Zyra</div>
+    <h1 class="poster-title">Modular, Reproducible Data&nbsp;Workflows for&nbsp;Science</h1>
+    <p class="poster-subtitle">An Open-Source Python Framework by NOAA Global Systems Laboratory</p>
+
+    <div class="author-block">
+      <span class="author-name">Eric Hackathorn</span>
+      <span class="author-org">NOAA Global Systems Laboratory</span>
+      <span class="author-orcid">
+        <span class="orcid-dot">iD</span>
+        0000-0002-9693-2093
+      </span>
+    </div>
+
+    <div class="badges">
+      <a href="https://pypi.org/project/zyra/" class="badge">
+        <span class="badge-pip pip-pypi">Pi</span>
+        <span class="badge-label">PyPI</span>
+        <span class="badge-value">zyra</span>
+      </a>
+      <a href="https://github.com/NOAA-GSL/zyra" class="badge">
+        <span class="badge-pip pip-gh"><svg width="10" height="10" viewBox="0 0 16 16" fill="white"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0016 8c0-4.42-3.58-8-8-8z"/></svg></span>
+        <span class="badge-label">GitHub</span>
+        <span class="badge-value">NOAA-GSL/zyra</span>
+      </a>
+      <a href="https://noaa-gsl.github.io/zyra/" class="badge">
+        <span class="badge-pip pip-docs"><svg width="9" height="9" viewBox="0 0 10 10" fill="none"><rect x="1" y="0" width="8" height="10" rx="1" stroke="white" stroke-width="1.2" fill="none"/><line x1="3" y1="3" x2="7" y2="3" stroke="white" stroke-width="0.8"/><line x1="3" y1="5" x2="7" y2="5" stroke="white" stroke-width="0.8"/><line x1="3" y1="7" x2="5.5" y2="7" stroke="white" stroke-width="0.8"/></svg></span>
+        <span class="badge-label">Docs</span>
+        <span class="badge-value">Sphinx</span>
+      </a>
+      <a href="https://doi.org/10.5281/zenodo.16923323" class="badge">
+        <span class="badge-pip pip-doi">DOI</span>
+        <span class="badge-label">DOI</span>
+        <span class="badge-value">10.5281/zenodo.16923323</span>
+      </a>
+      <span class="badge">
+        <span class="badge-pip pip-lic"><svg width="9" height="9" viewBox="0 0 10 10" fill="none"><circle cx="5" cy="5" r="4" stroke="white" stroke-width="1.2" fill="none"/><path d="M3.5 5.5 L4.5 6.5 L7 4" stroke="white" stroke-width="1" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></span>
+        <span class="badge-label">License</span>
+        <span class="badge-value">Apache-2.0</span>
+      </span>
+    </div>
+  </div>
+</div>
+
+  </div>
+
+  <!-- Gradient bridge from header -->
+
+  <div class="challenge-transition"></div>
+
+  <!-- ════════════ SECTION 2: THE CHALLENGE ════════════ -->
+
+  <div class="challenge-section">
+    <div class="challenge-card">
+
+  <!-- Illustrated vine-cable border frame -->
+  <div class="challenge-frame">
+    <img src="zyra-light-border.png" alt="" aria-hidden="true">
+  </div>
+
+  <div class="challenge-inner">
+
+    <!-- Left: Problem text -->
+    <div class="challenge-text">
+      <div class="section-tag">
+        <div class="diamond"></div>
+        <span>Problem Statement</span>
+      </div>
+
+      <h2 class="challenge-heading">The Challenge</h2>
+
+      <div class="challenge-body">
+        <p>
+          Environmental and scientific workflows span
+          <span class="em-bold">heterogeneous data sources</span>&hairsp;—&hairsp;<span class="tok">HTTP</span>&ensp;<span class="tok">FTP</span>&ensp;<span class="tok">S3</span>&ensp;<span class="tok">APIs</span>&hairsp;—&hairsp;and
+          <span class="em-bold">diverse formats</span> such as
+          <span class="tok">GRIB2</span>&ensp;<span class="tok">NetCDF</span>&ensp;<span class="tok">GeoTIFF</span>.
+          They require repeatable transformation chains and produce outputs ranging from static maps and animations to interactive pages and publishable datasets.
+          Existing approaches often rely on ad-hoc scripts that break when data changes and lack reproducibility across teams and environments.
+        </p>
+        <p>
+          <span class="em-bold">Zyra</span> (pronounced <em>Zy-rah</em>) provides a lightweight, CLI-first framework that
+          standardizes these common steps while remaining fully extensible for domain-specific logic.
+          Think of it as a garden for your data: you plant seeds (from the web, satellites, or experiments), Zyra helps you nurture them (through filtering, analysis, and processing), and you harvest insights as visualizations, reports, and interactive media.
+          It's designed to make science not just rigorous, but also accessible, transparent, and beautiful.
+        </p>
+      </div>
+    </div>
+
+    <!-- Right: Tangled paths graphic (dramatically revised) -->
+    <div class="challenge-graphic">
+      <svg viewBox="0 0 380 300" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <defs>
+          <!-- Subtle grid background -->
+          <pattern id="grid" width="22" height="22" patternUnits="userSpaceOnUse">
+            <path d="M 22 0 L 0 0 0 22" fill="none" stroke="#D8D7D3" stroke-width="0.5" opacity="0.4"/>
+          </pattern>
+
+          <!-- Glow for break markers -->
+          <filter id="warn-glow">
+            <feGaussianBlur stdDeviation="3" result="blur"/>
+            <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+          </filter>
+
+          <!-- Source node gradient -->
+          <linearGradient id="srcGrad" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stop-color="#00172D"/>
+            <stop offset="100%" stop-color="#002a4a"/>
+          </linearGradient>
+
+          <!-- Tangled path gradients -->
+          <linearGradient id="tangleA" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stop-color="#5F9DAE"/>
+            <stop offset="100%" stop-color="#9AB2B1"/>
+          </linearGradient>
+          <linearGradient id="tangleB" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stop-color="#9AB2B1"/>
+            <stop offset="50%" stop-color="#A3A29D"/>
+            <stop offset="100%" stop-color="#D8D7D3"/>
+          </linearGradient>
+
+          <!-- Break X marker -->
+          <symbol id="breakX" viewBox="0 0 20 20">
+            <circle cx="10" cy="10" r="9" fill="#F44336" fill-opacity="0.12" stroke="#F44336" stroke-width="1.2" stroke-opacity="0.5"/>
+            <line x1="6" y1="6" x2="14" y2="14" stroke="#F44336" stroke-width="2" stroke-linecap="round" opacity="0.8"/>
+            <line x1="14" y1="6" x2="6" y2="14" stroke="#F44336" stroke-width="2" stroke-linecap="round" opacity="0.8"/>
+          </symbol>
+        </defs>
+
+        <!-- Background grid -->
+        <rect width="380" height="300" fill="url(#grid)" rx="5"/>
+
+        <!-- ── LAYER: Tangled connection lines (thicker, more dramatic) ── -->
+        <!-- HTTP → Map (semi-clean) -->
+        <path d="M62 68 C62 105, 80 135, 75 165 C70 190, 50 205, 55 238"
+              stroke="url(#tangleA)" stroke-width="3" opacity="0.45" stroke-linecap="round"/>
+        <!-- HTTP → Dataset (wild crossing) -->
+        <path d="M62 68 C85 100, 260 95, 300 238"
+              stroke="url(#tangleB)" stroke-width="2.5" opacity="0.3" stroke-dasharray="6 4" stroke-linecap="round"/>
+        <!-- FTP → Animation (dramatic tangle) -->
+        <path d="M148 68 C148 95, 40 125, 160 170 C220 195, 160 210, 165 238"
+              stroke="url(#tangleA)" stroke-width="3" opacity="0.4" stroke-linecap="round"/>
+        <!-- FTP → Map (crossing back over) -->
+        <path d="M148 68 C130 100, 105 140, 55 238"
+              stroke="url(#tangleB)" stroke-width="2.5" opacity="0.25" stroke-dasharray="8 5" stroke-linecap="round"/>
+        <!-- S3 → Dataset (somewhat clean) -->
+        <path d="M238 68 C238 105, 275 170, 300 238"
+              stroke="url(#tangleA)" stroke-width="3" opacity="0.4" stroke-linecap="round"/>
+        <!-- S3 → Map (long dramatic crossing) -->
+        <path d="M238 68 C210 100, 110 145, 55 238"
+              stroke="url(#tangleB)" stroke-width="2.5" opacity="0.25" stroke-dasharray="5 5" stroke-linecap="round"/>
+        <!-- API → Animation (tangled) -->
+        <path d="M322 68 C322 95, 270 115, 220 145 C170 170, 185 200, 165 238"
+              stroke="url(#tangleA)" stroke-width="3" opacity="0.4" stroke-linecap="round"/>
+        <!-- API → Dataset (short) -->
+        <path d="M322 68 C315 115, 305 175, 300 238"
+              stroke="url(#tangleB)" stroke-width="2.5" opacity="0.35" stroke-linecap="round"/>
+        <!-- Extra chaos lines -->
+        <path d="M62 68 C90 110, 180 100, 165 238"
+              stroke="#A3A29D" stroke-width="1.5" opacity="0.15" stroke-dasharray="3 6" stroke-linecap="round"/>
+        <path d="M322 68 C280 110, 100 165, 55 238"
+              stroke="#A3A29D" stroke-width="1.5" opacity="0.12" stroke-dasharray="4 7" stroke-linecap="round"/>
+
+        <!-- ── LAYER: Break/warning markers (larger, more alarming) ── -->
+        <g filter="url(#warn-glow)">
+          <use href="#breakX" x="108" y="108" width="20" height="20"/>
+          <use href="#breakX" x="80" y="158" width="18" height="18"/>
+          <use href="#breakX" x="240" y="128" width="18" height="18"/>
+          <use href="#breakX" x="185" y="178" width="16" height="16"/>
+        </g>
+
+        <!-- ── LAYER: Category labels ── -->
+        <text x="190" y="16" class="cg-label" fill="#8B8985" text-anchor="middle">Sources</text>
+        <text x="190" y="296" class="cg-label" fill="#8B8985" text-anchor="middle">Outputs</text>
+
+        <!-- ── LAYER: Source nodes (top row — bolder with icons) ── -->
+        <!-- HTTP -->
+        <rect x="22" y="28" width="76" height="34" rx="5" fill="url(#srcGrad)"/>
+        <svg x="28" y="33" width="18" height="18" viewBox="0 0 24 24">
+          <circle cx="12" cy="12" r="9" stroke="#5F9DAE" stroke-width="1.5" fill="none"/>
+          <ellipse cx="12" cy="12" rx="4.5" ry="9" stroke="#5F9DAE" stroke-width="1" fill="none"/>
+          <line x1="3" y1="12" x2="21" y2="12" stroke="#5F9DAE" stroke-width="1"/>
+        </svg>
+        <text x="64" y="50" class="cg-node" fill="#FEFEFE" text-anchor="middle">HTTP</text>
+
+        <!-- FTP -->
+        <rect x="112" y="28" width="72" height="34" rx="5" fill="url(#srcGrad)"/>
+        <svg x="118" y="33" width="18" height="18" viewBox="0 0 24 24">
+          <rect x="4" y="4" width="16" height="16" rx="2" stroke="#5F9DAE" stroke-width="1.5" fill="none"/>
+          <line x1="4" y1="10" x2="20" y2="10" stroke="#5F9DAE" stroke-width="1"/>
+          <line x1="12" y1="10" x2="12" y2="20" stroke="#5F9DAE" stroke-width="1"/>
+        </svg>
+        <text x="152" y="50" class="cg-node" fill="#FEFEFE" text-anchor="middle">FTP</text>
+
+        <!-- S3 -->
+        <rect x="200" y="28" width="68" height="34" rx="5" fill="url(#srcGrad)"/>
+        <svg x="206" y="33" width="18" height="18" viewBox="0 0 24 24">
+          <path d="M5 8 C5 5, 19 5, 19 8 L19 16 C19 19, 5 19, 5 16 Z" stroke="#5F9DAE" stroke-width="1.5" fill="none"/>
+          <path d="M5 8 C5 11, 19 11, 19 8" stroke="#5F9DAE" stroke-width="1" fill="none"/>
+        </svg>
+        <text x="240" y="50" class="cg-node" fill="#FEFEFE" text-anchor="middle">S3</text>
+
+        <!-- API -->
+        <rect x="282" y="28" width="72" height="34" rx="5" fill="url(#srcGrad)"/>
+        <svg x="288" y="34" width="16" height="16" viewBox="0 0 24 24">
+          <path d="M8 4 L4 8 L8 12" stroke="#5F9DAE" stroke-width="1.8" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+          <path d="M16 4 L20 8 L16 12" stroke="#5F9DAE" stroke-width="1.8" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+          <line x1="14" y1="3" x2="10" y2="13" stroke="#5F9DAE" stroke-width="1.2"/>
+        </svg>
+        <text x="322" y="50" class="cg-node" fill="#FEFEFE" text-anchor="middle">API</text>
+
+        <!-- ── LAYER: Format pills (bold, solid background) ── -->
+        <rect x="30" y="138" width="68" height="24" rx="12" fill="#00529E" fill-opacity="0.10" stroke="#00529E" stroke-width="1.2" stroke-opacity="0.35"/>
+        <text x="64" y="154" class="cg-node" font-size="9.5" fill="#00529E" text-anchor="middle" font-weight="600">GRIB2</text>
+
+        <rect x="148" y="150" width="76" height="24" rx="12" fill="#00529E" fill-opacity="0.10" stroke="#00529E" stroke-width="1.2" stroke-opacity="0.35"/>
+        <text x="186" y="166" class="cg-node" font-size="9.5" fill="#00529E" text-anchor="middle" font-weight="600">NetCDF</text>
+
+        <rect x="268" y="133" width="80" height="24" rx="12" fill="#00529E" fill-opacity="0.10" stroke="#00529E" stroke-width="1.2" stroke-opacity="0.35"/>
+        <text x="308" y="149" class="cg-node" font-size="9.5" fill="#00529E" text-anchor="middle" font-weight="600">GeoTIFF</text>
+
+        <!-- ── LAYER: Output nodes (bottom row — bolder with icons) ── -->
+        <!-- Maps -->
+        <rect x="14" y="242" width="80" height="34" rx="5" fill="none" stroke="#1A5A69" stroke-width="2"/>
+        <svg x="20" y="247" width="20" height="20" viewBox="0 0 24 24">
+          <rect x="3" y="3" width="18" height="18" rx="2" stroke="#1A5A69" stroke-width="1.5" fill="none"/>
+          <polyline points="5,17 9,11 12,14 16,9 19,13" fill="none" stroke="#5F9DAE" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+        </svg>
+        <text x="62" y="264" class="cg-node" font-size="10" fill="#1A5A69" text-anchor="middle">Maps</text>
+
+        <!-- Animations -->
+        <rect x="122" y="242" width="92" height="34" rx="5" fill="none" stroke="#1A5A69" stroke-width="2"/>
+        <svg x="128" y="248" width="18" height="18" viewBox="0 0 24 24">
+          <polygon points="6,4 20,12 6,20" fill="none" stroke="#1A5A69" stroke-width="1.8" stroke-linejoin="round"/>
+        </svg>
+        <text x="176" y="264" class="cg-node" font-size="10" fill="#1A5A69" text-anchor="middle">Animations</text>
+
+        <!-- Datasets -->
+        <rect x="242" y="242" width="96" height="34" rx="5" fill="none" stroke="#1A5A69" stroke-width="2"/>
+        <svg x="250" y="248" width="18" height="18" viewBox="0 0 24 24">
+          <rect x="3" y="3" width="18" height="18" rx="1.5" stroke="#1A5A69" stroke-width="1.5" fill="none"/>
+          <line x1="3" y1="9" x2="21" y2="9" stroke="#1A5A69" stroke-width="1"/>
+          <line x1="3" y1="15" x2="21" y2="15" stroke="#1A5A69" stroke-width="1"/>
+          <line x1="10" y1="3" x2="10" y2="21" stroke="#1A5A69" stroke-width="1"/>
+        </svg>
+        <text x="298" y="264" class="cg-node" font-size="10" fill="#1A5A69" text-anchor="middle">Datasets</text>
+
+        <!-- ── LAYER: "ad-hoc scripts" caption (larger, more alarming) ── -->
+        <rect x="115" y="190" width="152" height="26" rx="13" fill="#F44336" fill-opacity="0.08" stroke="#F44336" stroke-width="1" stroke-opacity="0.4"/>
+        <text x="191" y="207" font-family="Source Sans 3, sans-serif" font-size="10.5" font-weight="600" fill="#F44336" text-anchor="middle" opacity="0.8">ad-hoc scripts break here</text>
+
+      </svg>
+    </div>
+
+  </div>
+</div>
+
+<!-- Flow cue: vine-cable arrow pointing down -->
+<div class="flow-cue">
+  <img src="zyra-straight-arrow.png" alt="" aria-hidden="true">
+</div>
+
+  </div>
+
+  <!-- ════════════ SECTION 3: THE PIPELINE ════════════ -->
+
+  <div class="pipeline-section">
+
+<div class="section-tag">
+  <div class="diamond"></div>
+  <span>Architecture</span>
+</div>
+<h2 class="pipeline-heading">The Pipeline: 8 Composable Stages</h2>
+<p class="pipeline-sub">Use only what you need. Each stage streams via stdin/stdout for Unix-style chaining.</p>
+
+<!-- ── Hero pipeline visual ── -->
+<div class="pipeline-visual-wrap" id="pipelineWrap" onclick="openPipelineLightbox()">
+  <span class="zoom-hint">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.35-4.35"/><path d="M11 8v6M8 11h6"/></svg>
+    Click to zoom
+  </span>
+<div class="pipeline-visual" id="pipelineVisual">
+
+  <!-- FLOWING SVG BACKGROUND -->
+  <svg class="flow-bg" viewBox="0 0 1360 520" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <!-- Main flowing river path -->
+    <path d="M 160 190 C 250 170, 300 250, 400 220 C 500 190, 520 130, 620 160 C 720 190, 750 270, 850 240 C 950 210, 980 150, 1080 180 C 1180 210, 1200 270, 1200 240"
+          stroke="url(#mainFlow)" stroke-width="56" stroke-linecap="round" opacity="0.06"/>
+    <path d="M 160 190 C 250 170, 300 250, 400 220 C 500 190, 520 130, 620 160 C 720 190, 750 270, 850 240 C 950 210, 980 150, 1080 180 C 1180 210, 1200 270, 1200 240"
+          stroke="url(#mainFlow)" stroke-width="24" stroke-linecap="round" opacity="0.09"/>
+
+    <!-- Animated dots along path -->
+    <circle r="3.5" fill="var(--cable-blue)" opacity="0.3">
+      <animateMotion dur="8s" repeatCount="indefinite"
+        path="M 160 190 C 250 170, 300 250, 400 220 C 500 190, 520 130, 620 160 C 720 190, 750 270, 850 240 C 950 210, 980 150, 1080 180 C 1180 210, 1200 270, 1200 240"/>
+    </circle>
+    <circle r="3" fill="var(--ocean-blue)" opacity="0.25">
+      <animateMotion dur="8s" repeatCount="indefinite" begin="2.5s"
+        path="M 160 190 C 250 170, 300 250, 400 220 C 500 190, 520 130, 620 160 C 720 190, 750 270, 850 240 C 950 210, 980 150, 1080 180 C 1180 210, 1200 270, 1200 240"/>
+    </circle>
+    <circle r="3" fill="var(--leaf-green)" opacity="0.25">
+      <animateMotion dur="8s" repeatCount="indefinite" begin="5s"
+        path="M 160 190 C 250 170, 300 250, 400 220 C 500 190, 520 130, 620 160 C 720 190, 750 270, 850 240 C 950 210, 980 150, 1080 180 C 1180 210, 1200 270, 1200 240"/>
+    </circle>
+
+    <!-- Secondary decorative dashes -->
+    <path d="M 160 210 C 280 240, 350 170, 420 200" stroke="var(--cable-blue)" stroke-width="1.5" stroke-dasharray="4,8" opacity="0.12"/>
+    <path d="M 580 140 C 650 110, 700 190, 780 150" stroke="var(--ocean-blue)" stroke-width="1.5" stroke-dasharray="4,8" opacity="0.12"/>
+    <path d="M 1020 160 C 1080 190, 1120 140, 1200 170" stroke="var(--leaf-green)" stroke-width="1.5" stroke-dasharray="4,8" opacity="0.12"/>
+
+    <!-- Connecting arrows from sources -->
+    <path d="M 120 155 C 155 155, 180 175, 210 180" stroke="var(--cable-blue)" stroke-width="2" fill="none" marker-end="url(#arrowBlue)"/>
+    <path d="M 120 210 C 155 210, 185 200, 215 195" stroke="var(--cable-blue)" stroke-width="2" fill="none" marker-end="url(#arrowBlue)"/>
+    <path d="M 120 268 C 155 258, 180 230, 215 215" stroke="var(--cable-blue)" stroke-width="2" fill="none" marker-end="url(#arrowBlue)"/>
+
+    <!-- Arrows to outputs -->
+    <path d="M 1200 195 C 1230 170, 1260 150, 1280 145" stroke="var(--leaf-green)" stroke-width="2" fill="none" marker-end="url(#arrowGreen)" opacity="0.45"/>
+    <path d="M 1200 205 C 1240 205, 1260 200, 1280 200" stroke="var(--leaf-green)" stroke-width="2" fill="none" marker-end="url(#arrowGreen)" opacity="0.45"/>
+    <path d="M 1200 215 C 1230 240, 1260 255, 1280 255" stroke="var(--leaf-green)" stroke-width="2" fill="none" marker-end="url(#arrowGreen)" opacity="0.45"/>
+
+    <!-- Decorative scattered dots -->
+    <circle cx="350" cy="270" r="2.5" fill="var(--cable-blue)" opacity="0.08"/>
+    <circle cx="500" cy="120" r="2" fill="var(--ocean-blue)" opacity="0.08"/>
+    <circle cx="700" cy="290" r="2.5" fill="var(--ocean-blue)" opacity="0.06"/>
+    <circle cx="900" cy="120" r="2" fill="var(--ocean-blue)" opacity="0.08"/>
+    <circle cx="1100" cy="270" r="2" fill="var(--leaf-green)" opacity="0.08"/>
+
+    <defs>
+      <linearGradient id="mainFlow" x1="0" y1="0" x2="1" y2="0">
+        <stop offset="0%" stop-color="var(--cable-blue)"/>
+        <stop offset="45%" stop-color="var(--ocean-blue)"/>
+        <stop offset="100%" stop-color="var(--leaf-green)"/>
+      </linearGradient>
+      <marker id="arrowBlue" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="5" markerHeight="5" orient="auto-start-reverse">
+        <path d="M 0 0 L 10 5 L 0 10 z" fill="var(--cable-blue)"/>
+      </marker>
+      <marker id="arrowTeal" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="5" markerHeight="5" orient="auto-start-reverse">
+        <path d="M 0 0 L 10 5 L 0 10 z" fill="var(--ocean-blue)"/>
+      </marker>
+      <marker id="arrowGreen" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="5" markerHeight="5" orient="auto-start-reverse">
+        <path d="M 0 0 L 10 5 L 0 10 z" fill="var(--leaf-green)"/>
+      </marker>
+    </defs>
+  </svg>
+
+  <!-- PHASE LABELS -->
+  <div class="phase-label pl-ingest">Data Ingestion &amp; Transformation</div>
+  <div class="phase-label pl-viz">Visualization &amp; AI Narration</div>
+  <div class="phase-label pl-export">Verification &amp; Export</div>
+
+  <!-- SOURCE ICONS (left) -->
+  <div class="source-stack">
+    <div class="source-item">
+      <div class="source-icon" style="background:linear-gradient(135deg,#dbeafe,#bfdbfe)">
+        <svg width="26" height="26" viewBox="0 0 24 24" fill="none" stroke="var(--cable-blue)" stroke-width="2" stroke-linecap="round"><circle cx="12" cy="12" r="10"/><path d="M2 12h20M12 2a15.3 15.3 0 014 10 15.3 15.3 0 01-4 10 15.3 15.3 0 01-4-10 15.3 15.3 0 014-10z"/></svg>
+      </div>
+      <div class="source-label">HTTP</div>
+    </div>
+    <div class="source-item">
+      <div class="source-icon" style="background:linear-gradient(135deg,#fef3c7,#fde68a)">
+        <svg width="26" height="26" viewBox="0 0 24 24" fill="none" stroke="var(--amber)" stroke-width="2" stroke-linecap="round"><path d="M4 8l8-5 8 5M4 8v8l8 5M4 8l8 5M20 8v8l-8 5M20 8l-8 5M12 13v8"/></svg>
+      </div>
+      <div class="source-label">S3</div>
+    </div>
+    <div class="source-item">
+      <div class="source-icon" style="background:linear-gradient(135deg,#e0e7ff,#c7d2fe)">
+        <svg width="26" height="26" viewBox="0 0 24 24" fill="none" stroke="var(--ocean-blue)" stroke-width="2" stroke-linecap="round"><rect x="2" y="3" width="20" height="18" rx="3"/><path d="M2 9h20M8 9v12"/></svg>
+      </div>
+      <div class="source-label">FTP</div>
+    </div>
+  </div>
+
+  <!-- STAGE BUBBLES -->
+  <!-- 1 Import -->
+  <div class="stage-bubble" style="left:230px; top:140px">
+    <div class="stage-circle" style="background:linear-gradient(135deg,var(--cable-blue),#003d7a)">
+      <svg viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="2" stroke-linecap="round"><path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4M7 10l5 5 5-5M12 15V3"/></svg>
+    </div>
+    <div class="stage-label-txt">Import</div>
+    <div class="stage-cli-txt">acquire</div>
+  </div>
+
+  <!-- 2 Process -->
+  <div class="stage-bubble" style="left:395px; top:150px">
+    <div class="stage-circle" style="background:linear-gradient(135deg,var(--leaf-green),#1a4a08)">
+      <svg viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="2" stroke-linecap="round"><path d="M22 12h-4l-3 9L9 3l-3 9H2"/></svg>
+    </div>
+    <div class="stage-label-txt">Process</div>
+    <div class="stage-cli-txt">transform</div>
+  </div>
+
+  <!-- 3 Simulate (planned) -->
+  <div class="stage-bubble" style="left:540px; top:135px">
+    <div class="stage-circle planned">
+      <svg viewBox="0 0 24 24" fill="none" stroke="var(--neutral-700)" stroke-width="2" stroke-linecap="round"><path d="M14.7 6.3a1 1 0 000 1.4l1.6 1.6a1 1 0 001.4 0l3.77-3.77a6 6 0 01-7.94 7.94l-6.91 6.91a2.12 2.12 0 01-3-3l6.91-6.91a6 6 0 017.94-7.94l-3.76 3.76z"/></svg>
+    </div>
+    <div class="stage-label-txt" style="color:var(--neutral-700)">Simulate</div>
+    <div class="stage-cli-txt planned-cli">planned</div>
+  </div>
+
+  <!-- 4 Decide (planned) -->
+  <div class="stage-bubble" style="left:685px; top:112px">
+    <div class="stage-circle planned">
+      <svg viewBox="0 0 24 24" fill="none" stroke="var(--neutral-700)" stroke-width="2" stroke-linecap="round"><path d="M16 21v-2a4 4 0 00-4-4H5a4 4 0 00-4 4v2"/><circle cx="8.5" cy="7" r="4"/><polyline points="17 11 19 13 23 9"/></svg>
+    </div>
+    <div class="stage-label-txt" style="color:var(--neutral-700)">Decide</div>
+    <div class="stage-cli-txt planned-cli">planned</div>
+  </div>
+
+  <!-- 5 Visualize -->
+  <div class="stage-bubble" style="left:830px; top:180px">
+    <div class="stage-circle" style="background:linear-gradient(135deg,var(--olive),#3a4510)">
+      <svg viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="2" stroke-linecap="round"><rect x="3" y="3" width="18" height="18" rx="2"/><path d="M3 15l4-4 4 4 4-6 5 6"/></svg>
+    </div>
+    <div class="stage-label-txt">Visualize</div>
+    <div class="stage-cli-txt">render</div>
+  </div>
+
+  <!-- 6 Narrate -->
+  <div class="stage-bubble" style="left:975px; top:175px">
+    <div class="stage-circle" style="background:linear-gradient(135deg,var(--ocean-blue),#0e3a44)">
+      <svg viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="2" stroke-linecap="round"><path d="M12 2a3 3 0 00-3 3v7a3 3 0 006 0V5a3 3 0 00-3-3z"/><path d="M19 10v2a7 7 0 01-14 0v-2M12 19v3M8 22h8"/></svg>
+    </div>
+    <div class="stage-label-txt">Narrate</div>
+    <div class="stage-cli-txt">AI-driven</div>
+  </div>
+
+  <!-- 7 Verify -->
+  <div class="stage-bubble" style="left:1035px; top:130px">
+    <div class="stage-circle" style="background:linear-gradient(135deg,var(--seafoam),#3d7585)">
+      <svg viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="2" stroke-linecap="round"><path d="M9 12l2 2 4-4M20.618 5.984A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z"/></svg>
+    </div>
+    <div class="stage-label-txt">Verify</div>
+    <div class="stage-cli-txt">verify</div>
+  </div>
+
+  <!-- 8 Export -->
+  <div class="stage-bubble" style="left:1145px; top:160px">
+    <div class="stage-circle" style="background:linear-gradient(135deg,var(--cable-blue),#003d7a)">
+      <svg viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="2" stroke-linecap="round"><path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4M17 8l-5-5-5 5M12 3v12"/></svg>
+    </div>
+    <div class="stage-label-txt">Export</div>
+    <div class="stage-cli-txt">disseminate</div>
+  </div>
+
+  <!-- OUTPUT ICONS (right) -->
+  <div class="output-stack" style="right:18px; top:100px;">
+    <div class="source-item" style="flex-direction:row-reverse;">
+      <div class="source-icon" style="background:linear-gradient(135deg,#dcfce7,#bbf7d0)">
+        <svg width="26" height="26" viewBox="0 0 24 24" fill="none" stroke="var(--leaf-green)" stroke-width="2" stroke-linecap="round"><path d="M18 10h-1.26A8 8 0 109 20h9a5 5 0 000-10z"/></svg>
+      </div>
+      <div class="source-label">Cloud</div>
+    </div>
+    <div class="source-item" style="flex-direction:row-reverse;">
+      <div class="source-icon" style="background:linear-gradient(135deg,#dbeafe,#bfdbfe)">
+        <svg width="26" height="26" viewBox="0 0 24 24" fill="none" stroke="var(--cable-blue)" stroke-width="2" stroke-linecap="round"><rect x="2" y="2" width="20" height="8" rx="2"/><rect x="2" y="14" width="20" height="8" rx="2"/><circle cx="6" cy="6" r="1" fill="var(--cable-blue)"/><circle cx="6" cy="18" r="1" fill="var(--cable-blue)"/></svg>
+      </div>
+      <div class="source-label">S3</div>
+    </div>
+    <div class="source-item" style="flex-direction:row-reverse;">
+      <div class="source-icon" style="background:linear-gradient(135deg,#fef3c7,#fde68a)">
+        <svg width="26" height="26" viewBox="0 0 24 24" fill="none" stroke="var(--amber)" stroke-width="2" stroke-linecap="round"><path d="M22 19a2 2 0 01-2 2H4a2 2 0 01-2-2V5a2 2 0 012-2h5l2 3h9a2 2 0 012 2z"/></svg>
+      </div>
+      <div class="source-label">Local</div>
+    </div>
+  </div>
+
+  <!-- CALLOUT CARDS -->
+  <div class="callout" style="left:170px; top:310px">
+    <div class="callout-arrow" style="left:60px;"></div>
+    <div class="callout-title"><span class="ct-tag" style="background:var(--cable-blue)">Import</span> zyra acquire</div>
+    <div class="callout-text">Discover datasets via <code style="font-size:10px;">zyra search</code> (SOS catalog, OGC, remote APIs), then fetch from S3, FTP, REST, or HTTP with automatic retry and checksum validation.</div>
+  </div>
+
+  <div class="callout" style="left:275px; top:400px">
+    <div class="callout-arrow" style="left:110px;"></div>
+    <div class="callout-title"><span class="ct-tag" style="background:var(--leaf-green)">Process</span> zyra transform</div>
+    <div class="callout-text">Regrid, subset, and convert GRIB2, NetCDF, and GeoTIFF through configurable processing chains.</div>
+  </div>
+
+  <div class="callout" style="left:430px; top:340px; max-width:185px;">
+    <div class="callout-arrow" style="left:65px;"></div>
+    <div class="callout-title"><span class="ct-tag" style="background:var(--neutral-700)">Simulate</span> planned</div>
+    <div class="callout-text">Future stage for ensemble simulations and model experiments within the pipeline.</div>
+  </div>
+
+  <div class="callout" style="left:585px; top:265px; max-width:185px;">
+    <div class="callout-arrow" style="left:65px;"></div>
+    <div class="callout-title"><span class="ct-tag" style="background:var(--neutral-700)">Decide</span> planned</div>
+    <div class="callout-text">Future stage for automated decision-support logic and threshold-based alerting.</div>
+  </div>
+
+  <div class="callout" style="left:715px; top:340px">
+    <div class="callout-arrow" style="left:85px;"></div>
+    <div class="callout-title"><span class="ct-tag" style="background:var(--olive)">Visualize</span> zyra render</div>
+    <div class="callout-text">Generate publication-quality maps, plots, and multi-frame GIF animations from processed datasets.</div>
+  </div>
+
+  <div class="callout" style="left:890px; top:390px">
+    <div class="callout-arrow" style="left:62px;"></div>
+    <div class="callout-title"><span class="ct-tag" style="background:var(--ocean-blue)">Narrate</span> zyra narrate</div>
+    <div class="callout-text">AI-driven scientific captions via multi-agent critique with OpenAI, Ollama, or Gemini providers.</div>
+  </div>
+
+  <div class="callout" style="left:950px; top:275px; max-width:180px;">
+    <div class="callout-arrow" style="left:72px;"></div>
+    <div class="callout-title"><span class="ct-tag" style="background:var(--seafoam)">Verify</span> zyra verify</div>
+    <div class="callout-text">Check metadata, provenance records, and output integrity.</div>
+  </div>
+
+  <div class="callout" style="left:1100px; top:365px; max-width:170px;">
+    <div class="callout-arrow" style="left:42px;"></div>
+    <div class="callout-title"><span class="ct-tag" style="background:var(--cable-blue)">Export</span> disseminate</div>
+    <div class="callout-text">Push final products to S3, cloud, or local with full audit trail.</div>
+  </div>
+
+  <!-- FORMAT PILLS -->
+  <div class="format-pills" style="left:325px; top:278px">
+    <span class="fpill" style="background:var(--cable-blue)">GRIB2</span>
+    <span class="fpill" style="background:var(--ocean-blue)">NetCDF</span>
+    <span class="fpill" style="background:var(--seafoam)">GeoTIFF</span>
+  </div>
+
+  <!-- PHASE SUMMARIES -->
+  <div class="phase-summaries">
+    <div class="phase-summary" style="flex:1.2">
+      Discover datasets via search, then acquire<br>via HTTP, S3, or FTP and transform.
+    </div>
+    <div class="phase-summary" style="flex:1.6">
+      Generate maps, plots, and animations while AI agents<br>produce automated scientific summaries and reports.
+    </div>
+    <div class="phase-summary" style="flex:1">
+      Validate metadata quality before<br>disseminating to cloud or local storage.
+    </div>
+  </div>
+</div>
+</div><!-- end .pipeline-visual-wrap -->
+
+<!-- ── Table + Streaming example ── -->
+<div class="pipeline-details">
+
+  <div class="pipeline-table-wrap">
+    <table class="pipeline-table">
+      <thead>
+        <tr>
+          <th>#</th>
+          <th>Stage</th>
+          <th>Purpose</th>
+          <th>CLI</th>
+          <th>Status</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr><td class="stage-num">1</td><td>Import</td><td>Search &amp; fetch from HTTP/S, S3, FTP, REST API</td><td class="cli-cell">zyra acquire</td><td class="status-impl">Implemented</td></tr>
+        <tr><td class="stage-num">2</td><td>Process</td><td>Decode, subset, convert (GRIB2, NetCDF, GeoTIFF)</td><td class="cli-cell">zyra process</td><td class="status-impl">Implemented</td></tr>
+        <tr><td class="stage-num">3</td><td>Simulate</td><td>Generate synthetic/test data</td><td class="cli-cell">—</td><td class="status-plan">Planned</td></tr>
+        <tr><td class="stage-num">4</td><td>Decide</td><td>Parameter optimization and selection</td><td class="cli-cell">—</td><td class="status-plan">Planned</td></tr>
+        <tr><td class="stage-num">5</td><td>Visualize</td><td>Static maps, plots, animations, interactive</td><td class="cli-cell">zyra visualize</td><td class="status-impl">Implemented</td></tr>
+        <tr><td class="stage-num">6</td><td>Narrate</td><td>AI-driven captions, summaries, reports</td><td class="cli-cell">zyra narrate</td><td class="status-impl">Implemented</td></tr>
+        <tr><td class="stage-num">7</td><td>Verify</td><td>Quality checks and metadata validation</td><td class="cli-cell">zyra verify</td><td class="status-partial">Partial</td></tr>
+        <tr><td class="stage-num">8</td><td>Export</td><td>Push to S3, FTP, Vimeo, local, HTTP POST</td><td class="cli-cell">zyra export</td><td class="status-impl">Implemented</td></tr>
+      </tbody>
+    </table>
+  </div>
+
+  <div class="stream-block">
+    <div class="stream-label">Unix-Style Streaming</div>
+    <div class="stream-code"><span class="sc-cmd">zyra acquire</span> http $URL <span class="sc-flag">-o -</span> <span class="sc-pipe">|</span> \
+<span class="sc-cmd">zyra process</span> convert-format - netcdf <span class="sc-flag">--stdout</span> <span class="sc-pipe">|</span>   
+<span class="sc-cmd">zyra visualize</span> heatmap <span class="sc-flag">--input -</span> <span class="sc-flag">--var</span> TMP <span class="sc-flag">-o</span> plot.png</div>
+<p class="stream-note">
+Stages are composable — pipe any stage's output directly into the next. Every stage supports <code style="font-family:var(--font-mono);font-size:11px;color:var(--cable-blue)">stdin</code>/<code style="font-family:var(--font-mono);font-size:11px;color:var(--cable-blue)">stdout</code> for seamless chaining.
+</p>
+</div>
+
+</div>
+
+  </div>
+
+  <!-- ════════════ SECTION 4: HRRR USE CASE ════════════ -->
+
+  <div class="usecase-row" id="uc-row-45">
+
+<div class="usecase-card hrrr-card">
+
+  <div class="section-tag" style="margin-bottom:6px;">
+    <div class="diamond"></div>
+    <span>Use Case</span>
+  </div>
+
+  <h3 class="usecase-heading">HRRR Weather Model Processing</h3>
+  <p class="usecase-desc">
+    Acquire the latest High-Resolution Rapid Refresh forecast, convert to NetCDF, and visualize temperature — three commands, one pipeline.
+  </p>
+
+  <!-- Three-step code block with stage-colored indicators -->
+  <div class="code-steps">
+    <div class="code-step">
+      <div class="step-dot step-dot-import">
+        <svg viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="2.5" stroke-linecap="round"><path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4M7 10l5 5 5-5M12 15V3"/></svg>
+      </div>
+      <div class="step-code"><span class="step-stage-tag tag-import">① Import</span>
+<span class="cc-cmd">zyra acquire</span> http \
+  <span class="cc-url">https://noaa-hrrr-bdp-pds.s3.amazonaws.com/</span>
+  <span class="cc-url">hrrr.20240101/conus/hrrr.t00z.wrfsfcf00.grib2</span> \
+  <span class="cc-flag">-o</span> <span class="cc-file">hrrr.grib2</span></div>
+    </div>
+    <div class="code-step">
+      <div class="step-dot step-dot-process">
+        <svg viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="2.5" stroke-linecap="round"><path d="M22 12h-4l-3 9L9 3l-3 9H2"/></svg>
+      </div>
+      <div class="step-code"><span class="step-stage-tag tag-process">② Process</span>
+<span class="cc-cmd">zyra process</span> convert-format \
+  <span class="cc-file">hrrr.grib2</span> netcdf <span class="cc-flag">-o</span> <span class="cc-file">hrrr.nc</span></div>
+    </div>
+    <div class="code-step">
+      <div class="step-dot step-dot-visualize">
+        <svg viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="2.5" stroke-linecap="round"><rect x="3" y="3" width="18" height="18" rx="2"/><path d="M3 15l4-4 4 4 4-6 5 6"/></svg>
+      </div>
+      <div class="step-code"><span class="step-stage-tag tag-visualize">③ Visualize</span>
+<span class="cc-cmd">zyra visualize</span> heatmap \
+  <span class="cc-flag">--input</span> <span class="cc-file">hrrr.nc</span> <span class="cc-flag">--var</span> TMP \
+  <span class="cc-flag">--colorbar</span> <span class="cc-flag">--output</span> <span class="cc-file">hrrr_temp.png</span></div>
+    </div>
+  </div>
+
+  <!-- Flow connector: code → output -->
+  <div class="flow-connector">
+    <svg width="24" height="28" viewBox="0 0 24 28" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <line x1="12" y1="2" x2="12" y2="22" stroke="var(--neutral-600)" stroke-width="1.5" stroke-dasharray="3 3"/>
+      <path d="M7 18l5 7 5-7" stroke="var(--neutral-600)" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+    </svg>
+  </div>
+
+  <div class="usecase-image-wrap">
+    <div class="usecase-placeholder">
+      <svg width="48" height="48" viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <rect x="4" y="4" width="40" height="40" rx="4" stroke="var(--neutral-600)" stroke-width="1.5" fill="none"/>
+        <path d="M4 34l10-10 8 8 8-12 14 14" stroke="var(--neutral-600)" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+        <circle cx="16" cy="16" r="4" stroke="var(--neutral-600)" stroke-width="1.5" fill="none"/>
+        <!-- Tiny gradient squares to suggest heatmap -->
+        <rect x="10" y="28" width="4" height="4" rx="0.5" fill="var(--cable-blue)" opacity="0.2"/>
+        <rect x="15" y="28" width="4" height="4" rx="0.5" fill="var(--ocean-blue)" opacity="0.25"/>
+        <rect x="20" y="28" width="4" height="4" rx="0.5" fill="var(--leaf-green)" opacity="0.25"/>
+        <rect x="25" y="28" width="4" height="4" rx="0.5" fill="var(--amber)" opacity="0.3"/>
+        <rect x="30" y="28" width="4" height="4" rx="0.5" fill="var(--red)" opacity="0.25"/>
+      </svg>
+      <span>heatmap.png — replace with generated asset</span>
+    </div>
+  </div>
+  <p class="usecase-caption">Heatmap rendered by <code>zyra visualize heatmap</code></p>
+
+</div>
+
+<!-- ════════════ SECTION 5: DROUGHT PIPELINE ════════════ -->
+<div class="usecase-card">
+
+  <div class="section-tag" style="margin-bottom:6px;">
+    <div class="diamond"></div>
+    <span>Use Case</span>
+  </div>
+
+  <h3 class="usecase-heading">Drought Animation Pipeline</h3>
+  <p class="usecase-desc">
+    Discover datasets via SOS catalog, sync weekly drought risk frames from NOAA FTP, fill gaps, and compose an MP4 animation — six steps, one pipeline.
+  </p>
+
+  <!-- Six-step code block with stage-colored indicators -->
+  <div class="code-steps">
+    <div class="code-step">
+      <div class="step-dot step-dot-search">
+        <svg viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="2.5" stroke-linecap="round"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.35-4.35"/></svg>
+      </div>
+      <div class="step-code"><span class="step-stage-tag tag-search">D Discover</span>
+<span class="cc-cmd">zyra search</span> <span class="cc-url">"drought risk"</span> <span class="cc-flag">--profile</span> <span class="cc-file">sos</span> <span class="cc-flag">--select</span> 1</div>
+    </div>
+    <div class="code-step">
+      <div class="step-dot step-dot-import">
+        <svg viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="2.5" stroke-linecap="round"><path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4M7 10l5 5 5-5M12 15V3"/></svg>
+      </div>
+      <div class="step-code"><span class="step-stage-tag tag-import">① Import</span>
+<span class="cc-cmd">zyra acquire</span> ftp \
+  <span class="cc-url">ftp://ftp.nnvl.noaa.gov/SOS/DroughtRisk_Weekly</span> \
+  <span class="cc-flag">--sync-dir</span> <span class="cc-file">./frames</span> <span class="cc-flag">--since</span> P1Y</div>
+    </div>
+    <div class="code-step">
+      <div class="step-dot step-dot-process">
+        <svg viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="2.5" stroke-linecap="round"><path d="M11 19a8 8 0 100-16 8 8 0 000 16zM21 21l-4.35-4.35"/></svg>
+      </div>
+      <div class="step-code"><span class="step-stage-tag tag-process">② Process</span>
+<span class="cc-cmd">zyra process</span> scan-frames \
+  <span class="cc-file">./frames</span> <span class="cc-flag">--output</span> <span class="cc-file">manifest.json</span></div>
+    </div>
+    <div class="code-step">
+      <div class="step-dot step-dot-process">
+        <svg viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="2.5" stroke-linecap="round"><rect x="3" y="3" width="18" height="18" rx="2"/><path d="M12 8v8M8 12h8"/></svg>
+      </div>
+      <div class="step-code"><span class="step-stage-tag tag-process">③ Process</span>
+<span class="cc-cmd">zyra process</span> pad-missing \
+  <span class="cc-file">./frames</span> <span class="cc-flag">--fill</span> basemap</div>
+    </div>
+    <div class="code-step">
+      <div class="step-dot step-dot-visualize">
+        <svg viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="2.5" stroke-linecap="round"><polygon points="5,3 19,12 5,21"/></svg>
+      </div>
+      <div class="step-code"><span class="step-stage-tag tag-visualize">④ Visualize</span>
+<span class="cc-cmd">zyra visualize</span> compose-video \
+  <span class="cc-file">./frames</span> <span class="cc-flag">--fps</span> 4 <span class="cc-flag">--output</span> <span class="cc-file">video.mp4</span></div>
+    </div>
+    <div class="code-step">
+      <div class="step-dot step-dot-export">
+        <svg viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="2.5" stroke-linecap="round"><path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4M17 8l-5-5-5 5M12 3v12"/></svg>
+      </div>
+      <div class="step-code"><span class="step-stage-tag tag-export">⑤ Export</span>
+<span class="cc-cmd">zyra export</span> vimeo \
+  <span class="cc-file">video.mp4</span> <span class="cc-flag">--title</span> <span class="cc-url">"Drought Risk Weekly"</span></div>
+    </div>
+  </div>
+
+  <!-- Flow connector: pipeline → output -->
+  <div class="flow-connector">
+    <svg width="24" height="28" viewBox="0 0 24 28" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <line x1="12" y1="2" x2="12" y2="22" stroke="var(--neutral-600)" stroke-width="1.5" stroke-dasharray="3 3"/>
+      <path d="M7 18l5 7 5-7" stroke="var(--neutral-600)" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+    </svg>
+  </div>
+
+  <!-- Video preview link -->
+  <a href="https://vimeo.com/900195230/43090ded31" target="_blank" rel="noopener noreferrer" class="video-preview">
+    <div class="video-thumb">
+      <div class="video-play-btn">
+        <svg width="20" height="20" viewBox="0 0 24 24" fill="var(--navy)"><polygon points="6,3 20,12 6,21"/></svg>
+      </div>
+    </div>
+    <div class="video-bar">
+      <svg class="video-bar-icon" viewBox="0 0 24 24" fill="none" stroke="var(--seafoam)" stroke-width="2" stroke-linecap="round"><polygon points="5,3 19,12 5,21"/></svg>
+      <div class="video-bar-text"><strong>Watch on Vimeo</strong> — Drought Risk Weekly animation output</div>
+    </div>
+  </a>
+
+  <!-- Provenance callout -->
+  <div class="prov-callout">
+    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="var(--cable-blue)" stroke-width="2" stroke-linecap="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/><polyline points="9 12 11 14 15 10"/></svg>
+    <p>Each stage logs <strong>provenance</strong> — start time, duration, command, and exit code — to a <code>SQLite</code> store for full reproducibility.</p>
+  </div>
+
+</div>
+
+  </div>
+
+  <!-- ════════════ SECTIONS 6 & 7: NARRATION + PIPELINES ════════════ -->
+
+  <div class="usecase-row" id="uc-row-67">
+
+<!-- SECTION 6: AI/LLM NARRATION SWARM -->
+<div class="usecase-card" style="border-left-color:var(--ocean-blue);">
+
+  <div class="section-tag" style="margin-bottom:6px;">
+    <div class="diamond" style="background:var(--ocean-blue);"></div>
+    <span>Use Case</span>
+  </div>
+
+  <h3 class="usecase-heading">AI/LLM Narration Swarm</h3>
+  <p class="usecase-desc">
+    Zyra orchestrates multi-agent workflows where LLM-powered agents generate, critique, and refine narrative outputs — from intent to validated publication.
+  </p>
+
+  <!-- User intent example -->
+  <div class="user-intent-bubble">
+    <div class="user-intent-label">
+      <div class="user-intent-avatar">
+        <svg viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="2.5" stroke-linecap="round"><path d="M20 21v-2a4 4 0 00-4-4H8a4 4 0 00-4 4v2"/><circle cx="12" cy="7" r="4"/></svg>
+      </div>
+      <span class="user-intent-name">Scientist</span>
+    </div>
+    <div class="user-intent-text">
+      "Summarize this week's <em>HRRR temperature anomalies</em> for the Colorado Front Range and generate a <em>narrated briefing</em> with publication-quality maps."
+    </div>
+  </div>
+
+  <!-- Swarm orchestration SVG diagram -->
+  <div class="swarm-diagram">
+    <svg viewBox="0 0 420 380" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <defs>
+        <marker id="sArrow" viewBox="0 0 8 8" refX="7" refY="4" markerWidth="5" markerHeight="5" orient="auto-start-reverse">
+          <path d="M0 0 L8 4 L0 8z" fill="#5F9DAE"/>
+        </marker>
+      </defs>
+
+      <!-- ── Vertical spine arrows ── -->
+      <line x1="210" y1="42" x2="210" y2="68" stroke="#5F9DAE" stroke-width="1.5" marker-end="url(#sArrow)"/>
+      <line x1="210" y1="102" x2="210" y2="128" stroke="#5F9DAE" stroke-width="1.5" marker-end="url(#sArrow)"/>
+      <line x1="210" y1="162" x2="210" y2="188" stroke="#5F9DAE" stroke-width="1.5" marker-end="url(#sArrow)"/>
+
+      <!-- ── Fan-out arrows from DAG to agents ── -->
+      <path d="M160 228 C130 240, 85 255, 75 265" stroke="#5F9DAE" stroke-width="1.2" fill="none" marker-end="url(#sArrow)"/>
+      <path d="M190 228 C180 245, 165 255, 160 265" stroke="#5F9DAE" stroke-width="1.2" fill="none" marker-end="url(#sArrow)"/>
+      <path d="M230 228 C240 245, 255 255, 260 265" stroke="#5F9DAE" stroke-width="1.2" fill="none" marker-end="url(#sArrow)"/>
+      <path d="M260 228 C290 240, 335 255, 345 265" stroke="#5F9DAE" stroke-width="1.2" fill="none" marker-end="url(#sArrow)"/>
+
+      <!-- ── Converge arrows from agents to Provenance ── -->
+      <path d="M75 305 C85 320, 150 340, 175 345" stroke="#5F9DAE" stroke-width="1.2" fill="none" marker-end="url(#sArrow)"/>
+      <path d="M160 305 C170 320, 185 335, 195 345" stroke="#5F9DAE" stroke-width="1.2" fill="none" marker-end="url(#sArrow)"/>
+      <path d="M260 305 C250 320, 235 335, 225 345" stroke="#5F9DAE" stroke-width="1.2" fill="none" marker-end="url(#sArrow)"/>
+      <path d="M345 305 C335 320, 270 340, 245 345" stroke="#5F9DAE" stroke-width="1.2" fill="none" marker-end="url(#sArrow)"/>
+
+      <!-- ═══ NODES ═══ -->
+
+      <!-- User Intent -->
+      <rect x="125" y="10" width="170" height="32" rx="6" fill="#50452C"/>
+      <text x="210" y="31" text-anchor="middle" font-family="Source Sans 3, sans-serif" font-size="11" font-weight="600" fill="#FEFEFE">User Intent</text>
+      <text x="210" y="10" text-anchor="middle" font-family="Source Sans 3, sans-serif" font-size="7.5" fill="#D8D7D3" dy="-2">natural language</text>
+
+      <!-- Planner -->
+      <rect x="125" y="70" width="170" height="32" rx="6" fill="#1A5A69"/>
+      <text x="210" y="91" text-anchor="middle" font-family="Source Sans 3, sans-serif" font-size="11" font-weight="600" fill="#FEFEFE">Planner</text>
+      <text x="320" y="90" font-family="Source Code Pro, monospace" font-size="8.5" fill="#8B8985">zyra plan</text>
+
+      <!-- Value Engine -->
+      <rect x="125" y="130" width="170" height="32" rx="6" fill="#FFC107"/>
+      <text x="210" y="151" text-anchor="middle" font-family="Source Sans 3, sans-serif" font-size="11" font-weight="600" fill="#00172D">Value Engine</text>
+      <text x="320" y="150" font-family="Source Sans 3, sans-serif" font-size="8" fill="#8B8985">suggest augmentations</text>
+
+      <!-- Execution DAG -->
+      <rect x="120" y="190" width="180" height="38" rx="6" fill="#00529E"/>
+      <text x="210" y="214" text-anchor="middle" font-family="Source Sans 3, sans-serif" font-size="12" font-weight="700" fill="#FEFEFE">Execution DAG</text>
+      <text x="210" y="203" text-anchor="middle" font-family="Source Sans 3, sans-serif" font-size="7.5" fill="#bdd4f0">parallel / sequential</text>
+
+      <!-- Stage Agent: acquire -->
+      <rect x="30" y="270" width="90" height="34" rx="5" fill="#2C670C"/>
+      <text x="75" y="283" text-anchor="middle" font-family="Source Sans 3, sans-serif" font-size="7.5" fill="#bbf7d0">Stage Agent</text>
+      <text x="75" y="296" text-anchor="middle" font-family="Source Code Pro, monospace" font-size="9.5" font-weight="600" fill="#FEFEFE">acquire</text>
+
+      <!-- Stage Agent: process -->
+      <rect x="130" y="270" width="90" height="34" rx="5" fill="#2C670C"/>
+      <text x="175" y="283" text-anchor="middle" font-family="Source Sans 3, sans-serif" font-size="7.5" fill="#bbf7d0">Stage Agent</text>
+      <text x="175" y="296" text-anchor="middle" font-family="Source Code Pro, monospace" font-size="9.5" font-weight="600" fill="#FEFEFE">process</text>
+
+      <!-- Stage Agent: visualize -->
+      <rect x="230" y="270" width="90" height="34" rx="5" fill="#576216"/>
+      <text x="275" y="283" text-anchor="middle" font-family="Source Sans 3, sans-serif" font-size="7.5" fill="#e8ecc8">Stage Agent</text>
+      <text x="275" y="296" text-anchor="middle" font-family="Source Code Pro, monospace" font-size="9.5" font-weight="600" fill="#FEFEFE">visualize</text>
+
+      <!-- LLM Agent: narrate -->
+      <rect x="330" y="270" width="80" height="34" rx="5" fill="#1A5A69"/>
+      <text x="370" y="283" text-anchor="middle" font-family="Source Sans 3, sans-serif" font-size="7.5" fill="#a8d4df">LLM Agent</text>
+      <text x="370" y="296" text-anchor="middle" font-family="Source Code Pro, monospace" font-size="9.5" font-weight="600" fill="#FEFEFE">narrate</text>
+
+      <!-- Provenance -->
+      <rect x="140" y="346" width="140" height="30" rx="5" fill="#5F9DAE"/>
+      <text x="210" y="365" text-anchor="middle" font-family="Source Sans 3, sans-serif" font-size="11" font-weight="600" fill="#00172D">Provenance (SQLite)</text>
+
+    </svg>
+  </div>
+
+  <!-- Narration chain -->
+  <div style="font-family:var(--font-sans);font-size:11px;font-weight:600;color:var(--navy);margin-bottom:5px;text-transform:uppercase;letter-spacing:0.8px;">Narration Swarm Chain</div>
+  <div class="narration-chain">
+    <span class="nc-pill" style="background:var(--ocean-blue);">context</span>
+    <span class="nc-arrow">&rarr;</span>
+    <span class="nc-pill" style="background:var(--cable-blue);">summary</span>
+    <span class="nc-arrow">&rarr;</span>
+    <span class="nc-pill" style="background:var(--amber);color:var(--navy);">critic</span>
+    <span class="nc-arrow">&rarr;</span>
+    <span class="nc-pill" style="background:var(--leaf-green);">editor</span>
+  </div>
+
+  <!-- LLM Agnostic callout (replaces provider table) -->
+  <div class="guard-callout" style="margin-top:14px;">
+    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="var(--ocean-blue)" stroke-width="2" stroke-linecap="round"><path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5"/></svg>
+    <p><strong style="color:var(--ocean-blue);">LLM Agnostic</strong> &mdash; swap providers via <code>--provider</code>: OpenAI, Ollama, Gemini, or any compatible backend. Mock mode for offline testing.</p>
+  </div>
+
+  <!-- zyra plan output example -->
+  <div style="font-family:var(--font-sans);font-size:11px;font-weight:600;color:var(--navy);margin:14px 0 5px;text-transform:uppercase;letter-spacing:0.8px;">Intent &rarr; Executable Plan</div>
+  <div class="usecase-code" style="font-size:10px; line-height:1.55; margin-bottom:10px;"><span class="cc-cmd">zyra plan</span> <span class="cc-flag">--intent</span> <span class="cc-url">"Sync drought frames, fill gaps, render animation"</span>
+<span style="color:var(--neutral-600);">{ <span class="cc-flag">"agents"</span>: [
+    {<span class="cc-flag">"id"</span>: <span class="cc-url">"fetch_frames"</span>,      <span class="cc-flag">"stage"</span>: <span class="cc-url">"acquire"</span>},
+    {<span class="cc-flag">"id"</span>: <span class="cc-url">"scan_frames"</span>,      <span class="cc-flag">"stage"</span>: <span class="cc-url">"process"</span>},
+    {<span class="cc-flag">"id"</span>: <span class="cc-url">"pad_missing"</span>,      <span class="cc-flag">"stage"</span>: <span class="cc-url">"process"</span>},
+    {<span class="cc-flag">"id"</span>: <span class="cc-url">"compose_animation"</span>, <span class="cc-flag">"stage"</span>: <span class="cc-url">"visualize"</span>},
+    {<span class="cc-flag">"id"</span>: <span class="cc-url">"save_local"</span>,        <span class="cc-flag">"stage"</span>: <span class="cc-url">"decimate"</span>}  ],
+  <span class="cc-flag">"suggestions"</span>: [
+    {<span class="cc-flag">"stage"</span>: <span class="cc-url">"narrate"</span>, <span class="cc-flag">"confidence"</span>: <span style="color:var(--olive);font-weight:600;">0.88</span>}
+  ] }</span></div>
+
+  <!-- Guardrails callout -->
+  <div class="guard-callout">
+    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="var(--ocean-blue)" stroke-width="2" stroke-linecap="round"><path d="M9 12l2 2 4-4M20.618 5.984A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z"/></svg>
+    <p>Outputs validated against <code>Pydantic</code> schemas with optional guardrails via <code>RAIL</code> files for structured, reproducible results.</p>
+  </div>
+
+  <!-- Swarm orchestration command -->
+  <div style="font-family:var(--font-sans);font-size:11px;font-weight:600;color:var(--navy);margin:14px 0 5px;text-transform:uppercase;letter-spacing:0.8px;">Swarm Orchestration</div>
+  <div class="usecase-code" style="margin-bottom:0;"><span class="cc-cmd">zyra swarm</span> <span class="cc-file">drought_animation.yaml</span> \
+  <span class="cc-flag">--parallel</span> <span class="cc-flag">--memory</span> <span class="cc-file">provenance.sqlite</span></div>
+
+</div>
+
+<!-- SECTION 7: REPRODUCIBLE PIPELINE CONFIGS -->
+<div class="usecase-card">
+
+  <div class="section-tag" style="margin-bottom:6px;">
+    <div class="diamond"></div>
+    <span>Use Case</span>
+  </div>
+
+  <h3 class="usecase-heading">Reproducible Pipeline Configs</h3>
+  <p class="usecase-desc">
+    Define multi-stage pipelines as YAML — no scripting required. Override parameters at runtime, dry-run to preview commands, and share configs across teams.
+  </p>
+
+  <!-- YAML config block + commands — responsive zoom wrapper -->
+  <div class="code-zoom-wrap" id="configWrap" onclick="openCodeLightbox('configWrap')">
+    <span class="zoom-hint">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.35-4.35"/><path d="M11 8v6M8 11h6"/></svg>
+      Click to zoom
+    </span>
+    <div class="code-zoom-inner" id="configInner">
+
+  <!-- YAML config block -->
+  <div class="yaml-code"><span class="yk">name</span>: <span class="ys">FTP to Local Video</span>
+
+<span class="yk">stages</span>:
+<span class="yd">-</span> <span class="yk">stage</span>: <span class="yv">acquire</span>
+<span class="yk">command</span>: <span class="yv">ftp</span>
+<span class="yk">args</span>:
+<span class="yk">path</span>: <span class="ys">ftp://ftp.nnvl.noaa.gov/SOS/DroughtRisk_Weekly</span>
+<span class="yk">sync_dir</span>: <span class="ys">./frames</span>
+<span class="yk">since_period</span>: <span class="ys">"P1Y"</span>
+
+<span class="yd">-</span> <span class="yk">stage</span>: <span class="yv">visualize</span>
+<span class="yk">command</span>: <span class="yv">compose-video</span>
+<span class="yk">args</span>:
+<span class="yk">frames</span>: <span class="ys">./frames</span>
+<span class="yk">output</span>: <span class="ys">video.mp4</span>
+<span class="yk">fps</span>: <span class="yn">4</span>
+
+<span class="yd">-</span> <span class="yk">stage</span>: <span class="yv">export</span>
+<span class="yk">command</span>: <span class="yv">local</span>
+<span class="yk">args</span>:
+<span class="yk">input</span>: <span class="ys">video.mp4</span>
+<span class="yk">path</span>: <span class="ys">/output/video.mp4</span></div>
+
+  <!-- Run commands -->
+  <div class="usecase-code" style="margin-bottom:12px;"><span class="cc-cmd">zyra run</span> <span class="cc-file">pipeline.yaml</span>                          <span class="yc"># execute</span>
+
+<span class="cc-cmd">zyra run</span> <span class="cc-file">pipeline.yaml</span> <span class="cc-flag">--dry-run</span>                 <span class="yc"># preview commands</span>
+<span class="cc-cmd">zyra run</span> <span class="cc-file">pipeline.yaml</span> <span class="cc-flag">--set</span> visualize.fps=<span class="yn">8</span>     <span class="yc"># override parameters</span></div>
+
+  <!-- Feature pills -->
+  <div class="feature-pills">
+    <span class="feat-pill">
+      <svg viewBox="0 0 24 24" fill="none" stroke="var(--cable-blue)" stroke-width="2" stroke-linecap="round"><path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z"/><polyline points="14 2 14 8 20 8"/></svg>
+      Declarative YAML
+    </span>
+    <span class="feat-pill">
+      <svg viewBox="0 0 24 24" fill="none" stroke="var(--leaf-green)" stroke-width="2" stroke-linecap="round"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg>
+      Dry-Run Preview
+    </span>
+    <span class="feat-pill">
+      <svg viewBox="0 0 24 24" fill="none" stroke="var(--ocean-blue)" stroke-width="2" stroke-linecap="round"><path d="M11 4H4a2 2 0 00-2 2v14a2 2 0 002 2h14a2 2 0 002-2v-7"/><path d="M18.5 2.5a2.121 2.121 0 013 3L12 15l-4 1 1-4 9.5-9.5z"/></svg>
+      Runtime Overrides
+    </span>
+    <span class="feat-pill">
+      <svg viewBox="0 0 24 24" fill="none" stroke="var(--olive)" stroke-width="2" stroke-linecap="round"><path d="M17 21v-2a4 4 0 00-4-4H5a4 4 0 00-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 00-3-3.87M16 3.13a4 4 0 010 7.75"/></svg>
+      Team Sharing
+    </span>
+  </div>
+
+    </div><!-- .code-zoom-inner -->
+  </div><!-- .code-zoom-wrap -->
+
+</div>
+
+  </div>
+
+  <!-- ════════════ SECTION 8: BUILDING OFF THE FOUNDATION ════════════ -->
+
+  <div class="foundation-section">
+
+    <div class="section-tag" style="margin-bottom:6px;">
+      <div class="diamond" style="background:var(--ocean-blue);"></div>
+      <span>Architecture</span>
+    </div>
+
+    <h2 class="foundation-heading">Building Off the Foundation</h2>
+    <p class="foundation-sub">Three layers of access — from terminal commands to autonomous AI agents — all sharing the same pipeline architecture.</p>
+
+    <div class="foundation-layers">
+
+      <!-- LEFT COLUMN: API (layer 2) -->
+      <div class="foundation-col col-left">
+
+        <div class="foundation-layer-card flc-mcp" style="text-align:right;">
+          <div style="display:flex;justify-content:flex-end;"><div class="flc-number">3</div></div>
+          <div class="flc-abbrev" style="text-align:right;">MCP + AI Agents</div>
+          <div class="flc-title">Model Context Protocol</div>
+          <p class="flc-desc">Zyra exposes every pipeline stage as an <code>MCP tool</code>, letting LLM agents like Claude autonomously discover, compose, and execute scientific workflows. The AI layer transforms conversational intent into reproducible pipeline runs.</p>
+        </div>
+
+        <div class="foundation-layer-card flc-api" style="text-align:right;">
+          <div style="display:flex;justify-content:flex-end;"><div class="flc-number">2</div></div>
+          <div class="flc-abbrev" style="text-align:right;">Python API</div>
+          <div class="flc-title">Application Programming Interface</div>
+          <p class="flc-desc">Zyra's modular Python API extends the CLI with programmatic access — enabling custom processing modules, integration into existing data workflows, and automated dissemination pipelines via <code>import zyra</code>.</p>
+        </div>
+
+        <div class="foundation-layer-card flc-cli" style="text-align:right;">
+          <div style="display:flex;justify-content:flex-end;"><div class="flc-number">1</div></div>
+          <div class="flc-abbrev" style="text-align:right;">Command Line Interface</div>
+          <div class="flc-title">CLI — The Foundation</div>
+          <p class="flc-desc">The CLI empowers researchers and developers to quickly build, test, and reproduce visualization pipelines with simple, scriptable commands. Every stage streams via <code>stdin/stdout</code> for Unix-style composition.</p>
+        </div>
+
+      </div>
+
+      <!-- CENTER: Pyramid SVG -->
+      <div class="foundation-pyramid">
+        <svg viewBox="0 0 380 420" width="380" fill="none" xmlns="http://www.w3.org/2000/svg">
+          <defs>
+            <!-- Pyramid face gradients -->
+            <linearGradient id="pyrGreen1" x1="0" y1="0" x2="1" y2="1">
+              <stop offset="0%" stop-color="#2C670C"/>
+              <stop offset="100%" stop-color="#1a4a08"/>
+            </linearGradient>
+            <linearGradient id="pyrGreen2" x1="1" y1="0" x2="0" y2="1">
+              <stop offset="0%" stop-color="#3a7e12"/>
+              <stop offset="100%" stop-color="#2C670C"/>
+            </linearGradient>
+            <linearGradient id="pyrBlue1" x1="0" y1="0" x2="1" y2="1">
+              <stop offset="0%" stop-color="#00529E"/>
+              <stop offset="100%" stop-color="#003d7a"/>
+            </linearGradient>
+            <linearGradient id="pyrBlue2" x1="1" y1="0" x2="0" y2="1">
+              <stop offset="0%" stop-color="#0068c4"/>
+              <stop offset="100%" stop-color="#00529E"/>
+            </linearGradient>
+            <linearGradient id="pyrTeal1" x1="0" y1="0" x2="1" y2="1">
+              <stop offset="0%" stop-color="#1A5A69"/>
+              <stop offset="100%" stop-color="#0e3d4a"/>
+            </linearGradient>
+            <linearGradient id="pyrTeal2" x1="1" y1="0" x2="0" y2="1">
+              <stop offset="0%" stop-color="#247a8c"/>
+              <stop offset="100%" stop-color="#1A5A69"/>
+            </linearGradient>
+            <!-- Light stripe gradient -->
+            <linearGradient id="pyrStripe" x1="0" y1="0" x2="1" y2="0">
+              <stop offset="0%" stop-color="rgba(255,255,255,0.0)"/>
+              <stop offset="30%" stop-color="rgba(255,255,255,0.35)"/>
+              <stop offset="70%" stop-color="rgba(255,255,255,0.35)"/>
+              <stop offset="100%" stop-color="rgba(255,255,255,0.0)"/>
+            </linearGradient>
+            <!-- Subtle shadow for depth -->
+            <filter id="pyrShadow">
+              <feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#00172D" flood-opacity="0.12"/>
+            </filter>
+          </defs>
+
+          <!-- ═══ TIER 1: CLI (bottom, widest) ═══ -->
+          <g filter="url(#pyrShadow)">
+            <!-- Left face -->
+            <polygon points="40,390  190,390  190,310  90,310" fill="url(#pyrGreen1)"/>
+            <!-- Right face -->
+            <polygon points="190,390  340,390  290,310  190,310" fill="url(#pyrGreen2)"/>
+            <!-- Top face -->
+            <polygon points="90,310  290,310  240,286  140,286" fill="#3a7e12" opacity="0.5"/>
+          </g>
+          <!-- Light stripe between tier 1 and tier 2 -->
+          <rect x="100" y="280" width="180" height="8" fill="url(#pyrStripe)" rx="1"/>
+
+          <!-- ═══ TIER 2: API (middle) ═══ -->
+          <g filter="url(#pyrShadow)">
+            <!-- Left face -->
+            <polygon points="90,270  190,270  190,190  130,190" fill="url(#pyrBlue1)"/>
+            <!-- Right face -->
+            <polygon points="190,270  290,270  250,190  190,190" fill="url(#pyrBlue2)"/>
+            <!-- Top face -->
+            <polygon points="130,190  250,190  218,172  162,172" fill="#0068c4" opacity="0.5"/>
+          </g>
+          <!-- Light stripe between tier 2 and tier 3 -->
+          <rect x="138" y="166" width="104" height="8" fill="url(#pyrStripe)" rx="1"/>
+
+          <!-- ═══ TIER 3: MCP/AI (top, narrowest) ═══ -->
+          <g filter="url(#pyrShadow)">
+            <!-- Left face -->
+            <polygon points="130,158  190,158  190,85  165,85" fill="url(#pyrTeal1)"/>
+            <!-- Right face -->
+            <polygon points="190,158  250,158  215,85  190,85" fill="url(#pyrTeal2)"/>
+            <!-- Top face / peak -->
+            <polygon points="165,85  215,85  200,72  180,72" fill="#247a8c" opacity="0.5"/>
+          </g>
+
+          <!-- ═══ MCP icon at peak ═══ -->
+          <g transform="translate(175,30)">
+            <circle cx="15" cy="18" r="16" fill="rgba(26,90,105,0.15)" stroke="var(--ocean-blue)" stroke-width="1"/>
+            <path d="M10 14 L15 10 L20 14 M10 18 L15 22 L20 18 M8 16 L15 16 L22 16" stroke="white" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+          </g>
+
+          <!-- ═══ Layer labels on pyramid faces ═══ -->
+          <!-- CLI label -->
+          <text x="190" y="350" text-anchor="middle" font-family="Source Sans 3, sans-serif" font-size="18" font-weight="700" fill="white" opacity="0.85">CLI</text>
+          <text x="190" y="368" text-anchor="middle" font-family="Source Code Pro, monospace" font-size="10" fill="white" opacity="0.5">zyra [command]</text>
+
+          <!-- API label -->
+          <text x="190" y="232" text-anchor="middle" font-family="Source Sans 3, sans-serif" font-size="16" font-weight="700" fill="white" opacity="0.85">API</text>
+          <text x="190" y="248" text-anchor="middle" font-family="Source Code Pro, monospace" font-size="9.5" fill="white" opacity="0.5">import zyra</text>
+
+          <!-- MCP label -->
+          <text x="190" y="124" text-anchor="middle" font-family="Source Sans 3, sans-serif" font-size="14" font-weight="700" fill="white" opacity="0.85">MCP</text>
+          <text x="190" y="140" text-anchor="middle" font-family="Source Code Pro, monospace" font-size="9" fill="white" opacity="0.5">tools/discover</text>
+
+          <!-- ═══ Connector lines from pyramid to description cards ═══ -->
+          <!-- CLI → right col bottom -->
+          <!-- API → right col middle -->
+          <!-- MCP → left col top -->
+          <!-- Thin dotted connector lines -->
+          <line x1="42" y1="348" x2="4" y2="348" stroke="var(--leaf-green)" stroke-width="1" stroke-dasharray="3 3" opacity="0.5"/>
+          <line x1="92" y1="230" x2="4" y2="230" stroke="var(--cable-blue)" stroke-width="1" stroke-dasharray="3 3" opacity="0.5"/>
+          <line x1="132" y1="122" x2="4" y2="122" stroke="var(--ocean-blue)" stroke-width="1" stroke-dasharray="3 3" opacity="0.5"/>
+
+        </svg>
+      </div>
+
+      <!-- RIGHT COLUMN: empty spacer for visual balance — cards are on the left -->
+      <div class="foundation-col col-right" style="visibility:hidden;">
+        <!-- Mirror for layout balance -->
+        <div class="foundation-layer-card" style="flex:1 1 0;"></div>
+        <div class="foundation-layer-card" style="flex:1 1 0;"></div>
+        <div class="foundation-layer-card" style="flex:1 1 0;"></div>
+      </div>
+
+    </div>
+
+    <!-- Highlight cards row -->
+    <div class="foundation-highlights">
+
+      <div class="foundation-highlight-card fhc-cli">
+        <div class="fhc-icon">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><polyline points="4 17 10 11 4 5"/><line x1="12" y1="19" x2="20" y2="19"/></svg>
+        </div>
+        <div class="fhc-text">
+          <strong>Streaming CLI Pipes</strong>
+          Chain stages via <code>stdin/stdout</code> — acquire, process, and visualize in a single Unix pipeline with zero intermediate files.
+        </div>
+      </div>
+
+      <div class="foundation-highlight-card fhc-api">
+        <div class="fhc-icon">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><rect x="2" y="3" width="20" height="14" rx="2"/><line x1="8" y1="21" x2="16" y2="21"/><line x1="12" y1="17" x2="12" y2="21"/></svg>
+        </div>
+        <div class="fhc-text">
+          <strong>FastAPI Service Mode</strong>
+          Run <code>uvicorn zyra.api.server:app</code> to expose all pipeline stages as a REST API, enabling web dashboards and automated integrations.
+        </div>
+      </div>
+
+      <div class="foundation-highlight-card fhc-mcp">
+        <div class="fhc-icon">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M12 2L2 7l10 5 10-5-10-5z"/><path d="M2 17l10 5 10-5"/><path d="M2 12l10 5 10-5"/></svg>
+        </div>
+        <div class="fhc-text">
+          <strong>MCP Tool Discovery</strong>
+          LLM agents discover available pipeline tools at runtime — no hardcoded prompts. Zyra's MCP server advertises capabilities dynamically.
+        </div>
+      </div>
+
+      <div class="foundation-highlight-card fhc-fast">
+        <div class="fhc-icon">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/><path d="M9 12l2 2 4-4"/></svg>
+        </div>
+        <div class="fhc-text">
+          <strong>Same Pipeline, Every Layer</strong>
+          Whether invoked from bash, Python, REST, or an AI agent — every execution follows the same 8-stage architecture with full provenance.
+        </div>
+      </div>
+
+    </div>
+
+  </div>
+
+  <!-- ════════════ SECTIONS 10 & 11: FEATURES + GET STARTED ════════════ -->
+
+  <div class="features-section">
+
+<!-- SECTION 10: KEY FEATURES -->
+<div class="features-card">
+
+  <div class="section-tag" style="margin-bottom:6px;">
+    <div class="diamond" style="background:var(--seafoam);"></div>
+    <span>Capabilities</span>
+  </div>
+
+  <h3>Key Features</h3>
+
+  <ul class="feat-list">
+    <li>
+      <span class="feat-dot"></span>
+      <div><strong>Scientific formats:</strong> GRIB2, NetCDF, GeoTIFF with xarray, cfgrib, rasterio</div>
+    </li>
+    <li>
+      <span class="feat-dot"></span>
+      <div><strong>Connectors:</strong> HTTP/S, S3, FTP, REST API, Vimeo</div>
+    </li>
+    <li>
+      <span class="feat-dot"></span>
+      <div><strong>Visualization:</strong> Heatmaps, contours, vectors, particles, animations, interactive maps (Folium, Plotly)</div>
+    </li>
+    <li>
+      <span class="feat-dot"></span>
+      <div><strong>AI integration:</strong> Multi-agent narration swarm, planning engine, value engine, guardrails</div>
+    </li>
+    <li>
+      <span class="feat-dot"></span>
+      <div><strong>Provenance:</strong> SQLite-based event logging for full reproducibility</div>
+    </li>
+    <li>
+      <span class="feat-dot"></span>
+      <div><strong>Service mode:</strong> FastAPI REST API + MCP tools for LLM integration</div>
+    </li>
+    <li>
+      <span class="feat-dot"></span>
+      <div><strong>Modular extras:</strong> <code>pip install "zyra[visualization]"</code>, <code>"zyra[processing]"</code>, <code>"zyra[llm]"</code>, or <code>"zyra[all]"</code></div>
+    </li>
+  </ul>
+
+  <div class="feat-meta">
+    <span class="feat-meta-pill">Python 3.10+</span>
+    <span class="feat-meta-pill">Apache 2.0</span>
+    <span class="feat-meta-pill">CLI-first</span>
+    <span class="feat-meta-pill">Streaming-friendly</span>
+  </div>
+
+</div>
+
+<!-- SECTION 11: GET STARTED -->
+<div class="features-card" style="background:transparent;border:none;padding:0;flex:1 1 50%;">
+
+  <div class="get-started-footer" style="margin:0;">
+
+  <div class="code-zoom-wrap" id="getStartedWrap" onclick="openCodeLightbox('getStartedWrap')">
+    <span class="zoom-hint">
+      <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.35-4.35"/><path d="M11 8v6M8 11h6"/></svg>
+      Click to zoom
+    </span>
+    <div class="code-zoom-inner" id="getStartedInner" style="display:flex;gap:24px;align-items:flex-start;">
+
+    <div class="gs-main">
+      <div class="section-tag" style="margin-bottom:6px;">
+        <div class="diamond" style="background:var(--seafoam);"></div>
+        <span style="color:var(--seafoam);">Getting Started</span>
+      </div>
+
+      <h3 class="gs-heading">Get Started</h3>
+
+      <div class="gs-code"><span class="gs-cmd">pip install</span> zyra          <span class="gs-dim"># core</span>
+
+<span class="gs-cmd">pip install</span> "zyra[all]"   <span class="gs-dim"># everything</span>
+<span class="gs-cmd">zyra</span> --help               <span class="gs-dim"># explore CLI</span></div>
+
+      <div class="gs-links">
+        <a href="https://github.com/NOAA-GSL/zyra" class="gs-badge" target="_blank" rel="noopener noreferrer">
+          <span class="gs-badge-pip pip-gh"><svg aria-hidden="true" width="10" height="10" viewBox="0 0 16 16" fill="white"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0016 8c0-4.42-3.58-8-8-8z"/></svg></span>
+          <span class="gs-badge-label">GitHub</span>
+          <span class="gs-badge-value">NOAA-GSL/zyra</span>
+        </a>
+        <a href="https://pypi.org/project/zyra/" class="gs-badge" target="_blank" rel="noopener noreferrer">
+          <span class="gs-badge-pip pip-pypi">Pi</span>
+          <span class="gs-badge-label">PyPI</span>
+          <span class="gs-badge-value">zyra</span>
+        </a>
+        <a href="https://noaa-gsl.github.io/zyra/" class="gs-badge" target="_blank" rel="noopener noreferrer">
+          <span class="gs-badge-pip pip-docs"><svg aria-hidden="true" width="9" height="9" viewBox="0 0 10 10" fill="none"><rect x="1" y="0" width="8" height="10" rx="1" stroke="white" stroke-width="1.2" fill="none"/><line x1="3" y1="3" x2="7" y2="3" stroke="white" stroke-width="0.8"/><line x1="3" y1="5" x2="7" y2="5" stroke="white" stroke-width="0.8"/><line x1="3" y1="7" x2="5.5" y2="7" stroke="white" stroke-width="0.8"/></svg></span>
+          <span class="gs-badge-label">Docs</span>
+          <span class="gs-badge-value">noaa-gsl.github.io/zyra</span>
+        </a>
+        <a href="https://github.com/NOAA-GSL/zyra/wiki" class="gs-badge" target="_blank" rel="noopener noreferrer">
+          <span class="gs-badge-pip pip-docs"><svg aria-hidden="true" width="9" height="9" viewBox="0 0 10 10" fill="none"><rect x="1" y="0" width="8" height="10" rx="1" stroke="white" stroke-width="1.2" fill="none"/><line x1="3" y1="3" x2="7" y2="3" stroke="white" stroke-width="0.8"/><line x1="3" y1="5" x2="7" y2="5" stroke="white" stroke-width="0.8"/><line x1="3" y1="7" x2="5.5" y2="7" stroke="white" stroke-width="0.8"/></svg></span>
+          <span class="gs-badge-label">Wiki</span>
+          <span class="gs-badge-value">NOAA-GSL/zyra/wiki</span>
+        </a>
+        <a href="https://doi.org/10.5281/zenodo.16923323" class="gs-badge" target="_blank" rel="noopener noreferrer">
+          <span class="gs-badge-pip pip-doi">DOI</span>
+          <span class="gs-badge-label">DOI</span>
+          <span class="gs-badge-value">10.5281/zenodo.16923323</span>
+        </a>
+        <a href="https://assistant.zyra-project.org" class="gs-badge" target="_blank" rel="noopener noreferrer">
+          <span class="gs-badge-pip pip-assist"><svg aria-hidden="true" width="9" height="9" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="2.5" stroke-linecap="round"><path d="M21 15a2 2 0 01-2 2H7l-4 4V5a2 2 0 012-2h14a2 2 0 012 2z"/></svg></span>
+          <span class="gs-badge-label">Assistant</span>
+          <span class="gs-badge-value">assistant.zyra-project.org</span>
+        </a>
+      </div>
+    </div>
+
+    <div class="gs-qr">
+      <div class="gs-qr-box">
+        <img src="zyra-qr-code.png" alt="QR code linking to github.com/NOAA-GSL/zyra" width="84" height="84" style="display:block;border-radius:4px;">
+      </div>
+      <div class="gs-qr-label">Scan for repo</div>
+    </div>
+
+    </div><!-- .code-zoom-inner -->
+  </div><!-- .code-zoom-wrap -->
+
+  </div>
+
+</div>
+
+  </div>
+
+</div>
+</body>
+</html>

--- a/poster/scripts/build_poster.py
+++ b/poster/scripts/build_poster.py
@@ -1,0 +1,103 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Build the conference poster HTML from section fragments.
+
+Produces two files:
+  poster/html/zyra-poster.html       — Web view (scrollable, interactive)
+  poster/html/zyra-poster-print.html — Print layout (14400×10800px, 300 DPI)
+
+The print version uses a fully self-contained _print.css (no _styles.css
+dependency). Gallery section is excluded from print.
+
+Run from the repository root:
+    python poster/scripts/build_poster.py
+
+Output files work with file:// protocol — no server required.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+SECTIONS_DIR = REPO_ROOT / "poster" / "sections"
+OUTPUT_DIR = REPO_ROOT / "poster" / "html"
+WEB_OUTPUT = OUTPUT_DIR / "zyra-poster.html"
+PRINT_OUTPUT = OUTPUT_DIR / "zyra-poster-print.html"
+
+# Sections to exclude from print layout
+PRINT_EXCLUDE = {"sec-09-gallery"}
+
+
+def _read(path: Path) -> str:
+    """Read a file preserving original line endings."""
+    try:
+        return path.read_text(encoding="utf-8", errors="strict")
+    except FileNotFoundError:
+        print(f"ERROR: Missing file: {path}", file=sys.stderr)
+        sys.exit(1)
+    except OSError as exc:
+        print(f"ERROR: Cannot read {path}: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+
+def _write(path: Path, content: str, label: str, section_names: list[str]) -> None:
+    """Write output and print summary."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(content.encode("utf-8"))
+    size_kb = path.stat().st_size / 1024
+    line_count = content.count("\n")
+    print(f"Built {path.relative_to(REPO_ROOT)} ({label})")
+    print(f"  Sections: {len(section_names)} ({', '.join(section_names)})")
+    print(f"  Size:     {size_kb:.1f} KB")
+    print(f"  Lines:    {line_count}")
+
+
+def build() -> None:
+    # ── Discover section files ──
+    section_files = sorted(SECTIONS_DIR.glob("sec-*.html"))
+    if not section_files:
+        print("ERROR: No sec-*.html files found in", SECTIONS_DIR, file=sys.stderr)
+        sys.exit(1)
+
+    # ── Build WEB version ──
+    head = _read(SECTIONS_DIR / "_head.html")
+    styles = _read(SECTIONS_DIR / "_styles.css")
+    body_open = _read(SECTIONS_DIR / "_body-open.html")
+    footer = _read(SECTIONS_DIR / "_footer.html")
+
+    sections_html = [_read(sf) for sf in section_files]
+    web_parts = [head, styles, body_open, *sections_html, footer]
+    _write(
+        WEB_OUTPUT,
+        "\n".join(web_parts),
+        "web",
+        [f.stem for f in section_files],
+    )
+
+    # ── Build PRINT version ──
+    head_print = _read(SECTIONS_DIR / "_head-print.html")
+    print_css = _read(SECTIONS_DIR / "_print.css")  # self-contained print styles
+    body_open_print = _read(SECTIONS_DIR / "_body-open-print.html")
+    footer_print = _read(SECTIONS_DIR / "_footer-print.html")
+
+    print_sections = [
+        (sf, _read(sf)) for sf in section_files if sf.stem not in PRINT_EXCLUDE
+    ]
+    print_parts = [
+        head_print,
+        print_css,
+        body_open_print,
+        *[html for _, html in print_sections],
+        footer_print,
+    ]
+    _write(
+        PRINT_OUTPUT,
+        "\n".join(print_parts),
+        "print 300 DPI",
+        [sf.stem for sf, _ in print_sections],
+    )
+
+
+if __name__ == "__main__":
+    build()

--- a/poster/sections/_body-open-print.html
+++ b/poster/sections/_body-open-print.html
@@ -1,0 +1,4 @@
+</style>
+</head>
+<body>
+<div class="poster">

--- a/poster/sections/_footer-print.html
+++ b/poster/sections/_footer-print.html
@@ -1,0 +1,3 @@
+</div>
+</body>
+</html>

--- a/poster/sections/_head-print.html
+++ b/poster/sections/_head-print.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Zyra Conference Poster — 48×36″ Print (300 DPI)</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Source+Sans+3:ital,wght@0,300;0,400;0,500;0,600;0,700&family=Source+Code+Pro:wght@400;500;600&display=swap" rel="stylesheet">
+<style>

--- a/poster/sections/_print.css
+++ b/poster/sections/_print.css
@@ -1,0 +1,1743 @@
+/* ═══════════════════════════════════════════════════════════════════
+   PRINT LAYOUT — 48×36" poster at 300 DPI = 14400×10800px
+   ═══════════════════════════════════════════════════════════════════
+   FULLY SELF-CONTAINED — no dependency on _styles.css.
+
+   Structure:
+     Part 1 — Design tokens + reset
+     Part 2 — Component visual styles (colors, fonts, backgrounds)
+     Part 3 — Print layout overrides (grid, sizing, 300 DPI dimensions)
+
+   Typography (300 DPI, viewed from 3–4 ft):
+     120pt = 500px  — poster title / project name
+      48pt = 200px  — section headings
+      36pt = 150px  — subheadings
+      28pt = 117px  — body text (wide cols)
+      24pt = 100px  — body text (narrow cols), code
+      20pt =  83px  — captions, small text
+      16pt =  67px  — badges, tiny labels
+
+   Grid — 12 columns, 5 rows (total = 10800px):
+     Row 1 (1200px):  HEADER                             (12 cols)
+     Row 2 (2200px):  CHALLENGE (3)  |  PIPELINE (9)
+     Row 3 (2600px):  FEATURES (4)   |  REPRO (3)  |  FOUNDATION (5)
+     Row 4 (3100px):  NARRATION (3)  |  DROUGHT (5)  |  HRRR (4)
+     Row 5 (1700px):  NARRATION (3)  |  DROUGHT (5)  |  GET STARTED (4)
+   ═══════════════════════════════════════════════════════════════════ */
+
+
+/* ═══════════════════════════════════════════
+   PART 1 — DESIGN TOKENS + RESET
+   ═══════════════════════════════════════════ */
+:root {
+  /* Primary */
+  --navy:        #00172D;
+  --ocean-blue:  #1A5A69;
+  --cable-blue:  #00529E;
+  /* Accent */
+  --seafoam:     #5F9DAE;
+  --mist:        #9AB2B1;
+  --deep-teal:   #091A1B;
+  /* Earth */
+  --leaf-green:  #2C670C;
+  --olive:       #576216;
+  --soil:        #50452C;
+  /* Semantic */
+  --amber:       #FFC107;
+  --red:         #F44336;
+  /* Neutrals */
+  --neutral-900: #232323;
+  --neutral-700: #8B8985;
+  --neutral-600: #A3A29D;
+  --neutral-400: #D8D7D3;
+  --neutral-200: #F7F5EE;
+  --neutral-50:  #FEFEFE;
+  /* Typography */
+  --font-sans: 'Source Sans 3', 'Source Sans Pro', system-ui, -apple-system, sans-serif;
+  --font-mono: 'Source Code Pro', 'Fira Code', 'Consolas', monospace;
+}
+
+* { margin: 0; padding: 0; box-sizing: border-box; }
+
+body {
+  background: white;
+  padding: 0;
+  display: block;
+  font-family: var(--font-sans);
+}
+
+
+/* ═══════════════════════════════════════════
+   PART 2 — COMPONENT VISUAL STYLES
+   Colors, fonts, backgrounds, borders.
+   Print layout (Part 3) overrides dimensions.
+   ═══════════════════════════════════════════ */
+
+/* ── Header ── */
+.header {
+  position: relative;
+  overflow: hidden;
+  background: url('light-slide-background.png') center center / cover no-repeat;
+}
+.header::after {
+  content: '';
+  position: absolute;
+  bottom: 0; left: 0; right: 0;
+  height: 4px;
+  background: linear-gradient(90deg,
+    transparent 0%, var(--mist) 20%,
+    var(--seafoam) 50%, var(--mist) 80%,
+    transparent 100%);
+  z-index: 10;
+}
+.header-content {
+  position: relative;
+  z-index: 5;
+  display: flex;
+  align-items: stretch;
+}
+.header-left { display: none; }
+.header-right {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+  position: relative;
+}
+.header-dataviz {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  pointer-events: none;
+  overflow: hidden;
+}
+.header-dataviz svg {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+}
+.header-right > *:not(.header-dataviz) {
+  position: relative;
+  z-index: 1;
+}
+.project-name {
+  font-weight: 800;
+  color: var(--navy);
+  letter-spacing: -1.5px;
+}
+.poster-title {
+  font-weight: 600;
+  color: var(--ocean-blue);
+  letter-spacing: -0.3px;
+}
+.poster-subtitle {
+  font-weight: 400;
+  color: var(--neutral-700);
+  letter-spacing: 0.1px;
+}
+.vine-divider { opacity: 0.5; }
+.vine-divider img { width: 100%; height: 100%; object-fit: contain; }
+.author-block {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+.author-name { font-weight: 600; color: var(--neutral-900); }
+.author-org  { color: var(--neutral-700); }
+.author-orcid {
+  color: var(--neutral-600);
+  display: flex;
+  align-items: center;
+  gap: 5px;
+}
+.orcid-dot {
+  display: inline-flex;
+  border-radius: 50%;
+  background: #A6CE39;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+  color: #fff;
+}
+.badges { display: flex; flex-wrap: wrap; justify-content: center; }
+.badge {
+  display: inline-flex;
+  align-items: center;
+  font-weight: 500;
+  color: var(--navy);
+  background: rgba(254,254,254,0.92);
+  border: 1px solid var(--neutral-600);
+  text-decoration: none;
+  box-shadow: 0 1px 3px rgba(0,23,45,0.12);
+}
+.badge-pip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+  color: #fff;
+}
+.badge-pip svg { display: block; }
+.pip-pypi { background: #3775A9; }
+.pip-docs { background: var(--ocean-blue); }
+.pip-doi  { background: var(--amber); color: var(--navy); }
+.pip-lic  { background: var(--neutral-700); }
+.pip-gh   { background: var(--neutral-900); }
+.badge-label { color: var(--neutral-700); }
+.badge-value { font-weight: 600; color: var(--navy); }
+
+/* ── Section Tag (shared) ── */
+.section-tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+}
+.section-tag .diamond {
+  background: var(--cable-blue);
+  border-radius: 1.5px;
+  transform: rotate(45deg);
+  flex-shrink: 0;
+}
+.section-tag span {
+  font-family: var(--font-sans);
+  font-weight: 600;
+  letter-spacing: 1.5px;
+  text-transform: uppercase;
+  color: var(--cable-blue);
+}
+
+/* ── Challenge ── */
+.challenge-section { position: relative; }
+.challenge-card {
+  position: relative;
+  display: flex;
+  align-items: stretch;
+  overflow: hidden;
+}
+.challenge-frame {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  pointer-events: none;
+}
+.challenge-frame img { width: 100%; height: 100%; object-fit: fill; opacity: 0.10; }
+.challenge-inner {
+  position: relative;
+  z-index: 1;
+  width: 100%;
+  background: rgba(247, 245, 238, 0.85);
+  border-radius: 6px;
+}
+.challenge-inner::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: 6px;
+  background: repeating-linear-gradient(
+    135deg,
+    transparent, transparent 28px,
+    rgba(0,82,158,0.012) 28px,
+    rgba(0,82,158,0.012) 29px
+  );
+  pointer-events: none;
+}
+.challenge-text {
+  position: relative;
+  z-index: 1;
+}
+.challenge-heading {
+  font-family: var(--font-sans);
+  font-weight: 700;
+  color: var(--navy);
+  line-height: 1.25;
+  position: relative;
+  display: inline-block;
+}
+.challenge-heading::after {
+  content: '';
+  display: block;
+  width: 64px;
+  height: 3px;
+  background: linear-gradient(90deg, var(--cable-blue), var(--seafoam));
+  border-radius: 2px;
+  margin-top: 8px;
+  margin-bottom: 12px;
+}
+.challenge-body { position: relative; }
+.challenge-body p {
+  font-family: var(--font-sans);
+  font-weight: 400;
+  color: var(--neutral-900);
+}
+.challenge-body p + p { margin-top: 12px; }
+.em-bold { font-weight: 600; color: var(--navy); }
+.tok {
+  font-family: var(--font-mono);
+  font-weight: 500;
+  color: var(--cable-blue);
+  background: rgba(0,82,158,0.06);
+  border: 1px solid rgba(0,82,158,0.10);
+  letter-spacing: 0.3px;
+  white-space: nowrap;
+}
+.challenge-graphic {
+  position: relative;
+  z-index: 1;
+}
+.cg-node {
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  font-weight: 600;
+  letter-spacing: 0.4px;
+}
+.cg-label {
+  font-family: var(--font-sans);
+  font-size: 9.5px;
+  font-weight: 600;
+  letter-spacing: 1.2px;
+  text-transform: uppercase;
+}
+
+/* ── Pipeline ── */
+.pipeline-heading {
+  font-family: var(--font-sans);
+  font-weight: 700;
+  color: var(--navy);
+  line-height: 1.25;
+}
+.pipeline-sub {
+  font-family: var(--font-sans);
+  color: var(--neutral-700);
+}
+.pipeline-visual-wrap {
+  width: 100%;
+  overflow: hidden;
+  position: relative;
+}
+.pipeline-visual {
+  position: relative;
+  background: var(--neutral-50);
+  border-radius: 0;
+  border: none;
+  overflow: visible;
+  transform-origin: top left;
+}
+.pipeline-visual .flow-bg {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+}
+.phase-label {
+  position: absolute;
+  font-family: var(--font-sans);
+  font-weight: 700;
+  letter-spacing: -0.2px;
+  z-index: 5;
+}
+.pl-ingest { top: 16px; left: 55px; color: var(--cable-blue); }
+.pl-viz    { top: 16px; left: 510px; color: var(--ocean-blue); }
+.pl-export { top: 16px; right: 95px; color: var(--leaf-green); }
+.source-stack {
+  position: absolute;
+  left: 25px; top: 110px;
+  display: flex; flex-direction: column; gap: 22px;
+  z-index: 5;
+}
+.output-stack {
+  position: absolute;
+  right: 20px; top: 100px;
+  display: flex; flex-direction: column; gap: 22px;
+  z-index: 5;
+}
+.source-item { display: flex; align-items: center; gap: 9px; }
+.source-icon {
+  border-radius: 12px;
+  display: flex; align-items: center; justify-content: center;
+  box-shadow: 0 3px 12px rgba(0,0,0,0.07);
+}
+.source-label {
+  font-family: var(--font-sans);
+  font-weight: 700;
+  color: var(--navy);
+}
+.stage-bubble {
+  position: absolute;
+  z-index: 10;
+  text-align: center;
+}
+.stage-circle {
+  border-radius: 50%;
+  display: flex; align-items: center; justify-content: center;
+  margin: 0 auto;
+  box-shadow: 0 5px 20px rgba(0,0,0,0.11);
+  position: relative;
+}
+.stage-circle.planned {
+  box-shadow: 0 3px 12px rgba(0,0,0,0.05);
+  border: 2.5px dashed var(--neutral-700);
+  background: rgba(139,137,133,0.12) !important;
+}
+.stage-label-txt {
+  font-family: var(--font-sans);
+  font-weight: 700;
+  margin-top: 5px;
+  color: var(--navy);
+}
+.stage-cli-txt {
+  font-family: var(--font-mono);
+  color: var(--cable-blue);
+  background: rgba(0,82,158,0.07);
+  border-radius: 3px;
+  padding: 1px 6px;
+  display: inline-block;
+  margin-top: 2px;
+}
+.stage-cli-txt.planned-cli {
+  color: var(--neutral-700);
+  background: rgba(139,137,133,0.12);
+}
+.callout {
+  position: absolute;
+  z-index: 15;
+  background: white;
+  border-radius: 10px;
+  padding: 12px 14px;
+  box-shadow: 0 3px 16px rgba(0,0,0,0.07), 0 1px 3px rgba(0,0,0,0.03);
+  max-width: 200px;
+}
+.callout-arrow {
+  position: absolute;
+  top: -5px;
+  width: 10px; height: 10px;
+  background: white;
+  transform: rotate(45deg);
+  box-shadow: -1px -1px 2px rgba(0,0,0,0.03);
+}
+.callout-title, .callout-text { position: relative; z-index: 2; }
+.callout-title {
+  font-family: var(--font-sans);
+  font-weight: 700;
+  color: var(--navy);
+  margin-bottom: 3px;
+  display: flex; align-items: center; gap: 5px;
+}
+.ct-tag {
+  font-family: var(--font-mono);
+  font-weight: 600;
+  color: white;
+  border-radius: 3px;
+}
+.callout-text {
+  font-family: var(--font-sans);
+  color: var(--neutral-700);
+  line-height: 1.4;
+}
+.format-pills {
+  position: absolute;
+  display: flex; gap: 5px;
+  z-index: 12;
+}
+.fpill {
+  font-family: var(--font-mono);
+  font-weight: 600;
+  color: white;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.1);
+}
+.phase-summaries {
+  position: absolute;
+  bottom: 8px;
+  left: 0; right: 0;
+  display: flex;
+  z-index: 5;
+}
+.phase-summary {
+  flex: 1;
+  text-align: center;
+  font-family: var(--font-sans);
+  color: var(--neutral-700);
+  line-height: 1.4;
+  padding: 0 36px;
+}
+
+/* ── Use Case Cards ── */
+.usecase-card {
+  background: var(--neutral-50);
+  border: 1px solid var(--neutral-400);
+  border-left: 4px solid var(--cable-blue);
+  position: relative;
+}
+.usecase-heading {
+  font-family: var(--font-sans);
+  font-weight: 700;
+  color: var(--ocean-blue);
+  line-height: 1.3;
+}
+.usecase-desc {
+  font-family: var(--font-sans);
+  color: var(--neutral-900);
+  line-height: 1.55;
+}
+.usecase-code {
+  background: var(--neutral-200);
+  border: 1px solid var(--neutral-400);
+  border-radius: 6px;
+  font-family: var(--font-mono);
+  color: var(--neutral-900);
+  white-space: pre;
+  overflow-x: auto;
+  position: relative;
+}
+.usecase-code::after {
+  content: 'bash';
+  position: absolute;
+  font-family: var(--font-mono);
+  font-weight: 500;
+  color: var(--neutral-600);
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
+}
+.usecase-code .cc-cmd  { color: var(--cable-blue); font-weight: 600; }
+.usecase-code .cc-url  { color: var(--ocean-blue); }
+.usecase-code .cc-flag { color: var(--olive); }
+.usecase-code .cc-file { color: var(--leaf-green); font-weight: 500; }
+.code-steps {
+  display: flex;
+  flex-direction: column;
+}
+.code-step {
+  display: flex;
+  align-items: flex-start;
+  background: var(--neutral-200);
+  border: 1px solid var(--neutral-400);
+  border-bottom: none;
+  position: relative;
+}
+.code-step:first-child { border-radius: 6px 6px 0 0; }
+.code-step:last-child {
+  border-bottom: 1px solid var(--neutral-400);
+  border-radius: 0 0 6px 6px;
+}
+.code-step::after {
+  content: 'bash';
+  position: absolute;
+  font-family: var(--font-mono);
+  font-weight: 500;
+  color: var(--neutral-600);
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
+  display: none;
+}
+.code-step:first-child::after { display: block; }
+.step-dot {
+  flex-shrink: 0;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--font-sans);
+  font-weight: 700;
+  color: #fff;
+  box-shadow: 0 3px 10px rgba(0,0,0,0.12);
+}
+.step-dot-import    { background: linear-gradient(135deg, var(--cable-blue), #003d7a); }
+.step-dot-process   { background: linear-gradient(135deg, var(--leaf-green), #1a4a08); }
+.step-dot-visualize { background: linear-gradient(135deg, var(--olive), #3a4510); }
+.step-dot-export    { background: linear-gradient(135deg, var(--cable-blue), #003d7a); }
+.step-dot-search    { background: linear-gradient(135deg, var(--seafoam), #3d7585); }
+.step-stage-tag {
+  display: inline-block;
+  font-family: var(--font-mono);
+  font-weight: 600;
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
+}
+.step-stage-tag.tag-import    { background: rgba(0,82,158,0.1); color: var(--cable-blue); }
+.step-stage-tag.tag-process   { background: rgba(44,103,12,0.1); color: var(--leaf-green); }
+.step-stage-tag.tag-visualize { background: rgba(87,98,22,0.1); color: var(--olive); }
+.step-stage-tag.tag-export    { background: rgba(0,82,158,0.1); color: var(--cable-blue); }
+.step-stage-tag.tag-search    { background: rgba(95,157,174,0.12); color: var(--seafoam); }
+.step-code {
+  font-family: var(--font-mono);
+  color: var(--neutral-900);
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+.flow-connector {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--neutral-600);
+}
+.flow-connector svg { opacity: 0.5; }
+
+/* HRRR watermark */
+.hrrr-card { position: relative; overflow: hidden; }
+.hrrr-card::before {
+  content: '';
+  position: absolute;
+  top: 50%; right: -20px;
+  width: 200px; height: 140px;
+  background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 200 140'%3E%3Cpath d='M30,20 Q40,15 55,18 L70,15 Q85,12 95,18 L110,22 Q125,20 140,15 L155,18 Q168,22 175,28 L178,35 Q180,45 175,55 L170,65 Q165,72 160,78 L155,85 Q148,92 140,95 L130,98 Q118,102 105,100 L90,95 Q78,90 68,85 L55,80 Q42,75 35,68 L28,58 Q22,48 25,38 L28,28 Q28,22 30,20Z' fill='none' stroke='%231A5A69' stroke-width='0.8' opacity='0.06'/%3E%3C/svg%3E") no-repeat center center;
+  background-size: contain;
+  pointer-events: none;
+  opacity: 0.5;
+}
+
+/* Placeholder / caption */
+.usecase-placeholder {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  color: var(--neutral-600);
+}
+.usecase-placeholder svg { opacity: 0.35; }
+.usecase-placeholder span {
+  font-family: var(--font-sans);
+  font-weight: 500;
+}
+.usecase-caption {
+  font-family: var(--font-sans);
+  font-style: italic;
+  color: var(--neutral-700);
+  text-align: center;
+}
+.usecase-caption code {
+  font-family: var(--font-mono);
+  font-style: normal;
+  color: var(--cable-blue);
+  background: rgba(0,82,158,0.06);
+  padding: 0 4px;
+  border-radius: 2px;
+}
+
+/* DAG diagram */
+.dag-wrap {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+.dag-node { display: flex; align-items: center; gap: 10px; width: 100%; }
+.dag-box {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  color: white;
+  font-family: var(--font-mono);
+  font-weight: 600;
+  letter-spacing: 0.2px;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.08);
+}
+.dag-box svg { flex-shrink: 0; }
+.dag-stage-tag {
+  font-family: var(--font-sans);
+  font-weight: 500;
+  color: var(--neutral-600);
+  white-space: nowrap;
+  text-align: right;
+}
+.dag-arrow { display: flex; justify-content: center; }
+.dag-arrow svg { opacity: 0.4; }
+
+/* Video preview */
+.video-preview {
+  display: block;
+  overflow: hidden;
+  border: 1px solid var(--neutral-400);
+  background: var(--navy);
+  text-decoration: none;
+  position: relative;
+}
+.video-thumb {
+  width: 100%;
+  background: url('drought-thumb.png') center center / cover no-repeat;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+  overflow: hidden;
+}
+.video-thumb::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: rgba(0,23,45,0.2);
+}
+.video-play-btn {
+  border-radius: 50%;
+  background: rgba(254,254,254,0.9);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1;
+  box-shadow: 0 3px 12px rgba(0,0,0,0.25);
+}
+.video-play-btn svg { margin-left: 3px; }
+.video-bar {
+  display: flex;
+  align-items: center;
+  background: var(--navy);
+}
+.video-bar-icon { flex-shrink: 0; }
+.video-bar-text {
+  font-family: var(--font-sans);
+  color: rgba(254,254,254,0.7);
+}
+.video-bar-text strong { color: var(--neutral-50); font-weight: 600; }
+
+/* Provenance callout */
+.prov-callout {
+  display: flex;
+  align-items: flex-start;
+  background: rgba(0,82,158,0.04);
+  border: 1px solid rgba(0,82,158,0.1);
+  border-radius: 5px;
+}
+.prov-callout svg { flex-shrink: 0; margin-top: 1px; }
+.prov-callout p {
+  font-family: var(--font-sans);
+  color: var(--neutral-900);
+  line-height: 1.5;
+}
+.prov-callout code {
+  font-family: var(--font-mono);
+  color: var(--cable-blue);
+  background: rgba(0,82,158,0.06);
+  padding: 0 3px;
+  border-radius: 2px;
+}
+
+/* Swarm diagram */
+.swarm-diagram svg { width: 100%; height: auto; }
+
+/* User intent bubble */
+.user-intent-bubble {
+  position: relative;
+  background: var(--neutral-200);
+  border: 1px solid var(--neutral-400);
+  border-radius: 12px 12px 12px 2px;
+}
+.user-intent-bubble::before {
+  content: '';
+  position: absolute;
+  bottom: -8px; left: 14px;
+  width: 0; height: 0;
+  border-left: 8px solid var(--neutral-400);
+  border-right: 8px solid transparent;
+  border-top: 8px solid var(--neutral-200);
+  border-bottom: 8px solid transparent;
+}
+.user-intent-label { display: flex; align-items: center; gap: 6px; margin-bottom: 6px; }
+.user-intent-avatar {
+  border-radius: 50%;
+  background: var(--soil);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.user-intent-name {
+  font-family: var(--font-sans);
+  font-weight: 600;
+  color: var(--neutral-700);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+.user-intent-text {
+  font-family: var(--font-sans);
+  font-style: italic;
+  color: var(--navy);
+  line-height: 1.5;
+}
+.user-intent-text em { font-style: normal; font-weight: 600; color: var(--ocean-blue); }
+
+/* Provider table */
+.provider-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-family: var(--font-sans);
+}
+.provider-table th {
+  text-align: left;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--navy);
+  border-bottom: 2px solid var(--neutral-400);
+}
+.provider-table td {
+  border-bottom: 1px solid var(--neutral-400);
+  color: var(--neutral-900);
+}
+.provider-table tr:last-child td { border-bottom: none; }
+.provider-table .prov-name { font-weight: 600; color: var(--ocean-blue); }
+.provider-table .prov-usage {
+  font-family: var(--font-mono);
+  color: var(--cable-blue);
+}
+
+/* Narration chain */
+.narration-chain {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+}
+.nc-pill {
+  font-family: var(--font-mono);
+  font-weight: 600;
+  border-radius: 12px;
+  color: white;
+}
+.nc-arrow { color: var(--neutral-600); }
+
+/* Guard callout */
+.guard-callout {
+  display: flex;
+  align-items: flex-start;
+  background: rgba(26,90,105,0.04);
+  border: 1px solid rgba(26,90,105,0.1);
+  border-radius: 5px;
+}
+.guard-callout svg { flex-shrink: 0; margin-top: 1px; }
+.guard-callout p {
+  font-family: var(--font-sans);
+  color: var(--neutral-900);
+  line-height: 1.5;
+}
+.guard-callout code {
+  font-family: var(--font-mono);
+  color: var(--ocean-blue);
+  background: rgba(26,90,105,0.06);
+  padding: 0 3px;
+  border-radius: 2px;
+}
+
+/* YAML code block */
+.yaml-code {
+  background: var(--neutral-200);
+  border: 1px solid var(--neutral-400);
+  border-radius: 6px;
+  font-family: var(--font-mono);
+  color: var(--neutral-900);
+  white-space: pre;
+  overflow-x: auto;
+  position: relative;
+}
+.yaml-code::after {
+  content: 'yaml';
+  position: absolute;
+  top: 6px; right: 10px;
+  font-family: var(--font-mono);
+  font-weight: 500;
+  color: var(--neutral-600);
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
+}
+.yaml-code .yk { color: var(--ocean-blue); font-weight: 600; }
+.yaml-code .yv { color: var(--cable-blue); }
+.yaml-code .ys { color: var(--leaf-green); }
+.yaml-code .yn { color: var(--olive); font-weight: 600; }
+.yaml-code .yd { color: var(--neutral-600); }
+.yaml-code .yc { color: var(--neutral-600); font-style: italic; }
+
+/* Code zoom (disable web interaction) */
+.code-zoom-wrap { width: 100%; overflow: hidden; position: relative; border-radius: 8px; }
+.code-zoom-inner { transform-origin: top left; }
+
+/* ── Pipeline Table ── */
+.pipeline-details {
+  display: flex;
+  gap: 28px;
+  align-items: flex-start;
+}
+.pipeline-table-wrap { flex: 1; min-width: 0; }
+.pipeline-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-family: var(--font-sans);
+}
+.pipeline-table th {
+  text-align: left;
+  font-weight: 600;
+  color: var(--navy);
+  border-bottom: 2px solid var(--neutral-400);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+.pipeline-table td {
+  border-bottom: 1px solid var(--neutral-400);
+  color: var(--neutral-900);
+  vertical-align: top;
+}
+.pipeline-table tr:last-child td { border-bottom: none; }
+.pipeline-table .stage-num {
+  font-weight: 700;
+  color: var(--cable-blue);
+  text-align: center;
+}
+.pipeline-table .cli-cell {
+  font-family: var(--font-mono);
+  color: var(--cable-blue);
+}
+.pipeline-table .status-impl {
+  color: var(--leaf-green);
+  font-weight: 600;
+}
+.pipeline-table .status-plan {
+  color: var(--neutral-700);
+  font-weight: 500;
+  font-style: italic;
+}
+.pipeline-table .status-partial {
+  color: var(--amber);
+  font-weight: 600;
+}
+
+/* Stream block */
+.stream-block { flex: 1; min-width: 0; }
+.stream-label {
+  font-family: var(--font-sans);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  color: var(--ocean-blue);
+}
+.stream-code {
+  background: var(--neutral-200);
+  border: 1px solid var(--neutral-400);
+  border-radius: 6px;
+  font-family: var(--font-mono);
+  color: var(--neutral-900);
+  line-height: 1.6;
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+.stream-code .sc-cmd { color: var(--cable-blue); font-weight: 600; }
+.stream-code .sc-pipe { color: var(--leaf-green); font-weight: 700; }
+.stream-code .sc-flag { color: var(--ocean-blue); }
+.stream-note {
+  font-family: var(--font-sans);
+  color: var(--neutral-700);
+  line-height: 1.5;
+}
+
+/* ── Features ── */
+.features-card {
+  background: var(--neutral-200);
+  border: 1px solid var(--neutral-400);
+  border-radius: 6px;
+}
+.features-card h3 {
+  font-family: var(--font-sans);
+  font-weight: 700;
+  color: var(--navy);
+}
+.feat-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+}
+.feat-list li {
+  display: flex;
+  align-items: flex-start;
+  font-family: var(--font-sans);
+  color: var(--neutral-900);
+  line-height: 1.5;
+}
+.feat-dot {
+  border-radius: 50%;
+  background: var(--seafoam);
+  flex-shrink: 0;
+}
+.feat-list li strong { color: var(--ocean-blue); font-weight: 700; }
+.feat-list li code {
+  font-family: var(--font-mono);
+  color: var(--cable-blue);
+  background: rgba(0,82,158,0.06);
+  padding: 0 3px;
+  border-radius: 2px;
+}
+.feat-meta {
+  border-top: 1px solid var(--neutral-400);
+  display: flex;
+  flex-wrap: wrap;
+}
+.feat-meta-pill {
+  font-family: var(--font-sans);
+  font-weight: 700;
+  color: var(--navy);
+  background: var(--neutral-50);
+  border: 1px solid var(--neutral-400);
+}
+.feature-pills { display: flex; flex-wrap: wrap; }
+.feat-pill {
+  display: inline-flex;
+  align-items: center;
+  font-family: var(--font-sans);
+  font-weight: 600;
+  background: var(--neutral-200);
+  border: 1px solid var(--neutral-400);
+  color: var(--navy);
+}
+.feat-pill svg { flex-shrink: 0; }
+
+/* ── Foundation ── */
+.foundation-section {
+  position: relative;
+  overflow: hidden;
+  background: linear-gradient(175deg, var(--neutral-50) 0%, var(--neutral-200) 100%);
+}
+.foundation-section::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(ellipse 600px 400px at 85% 60%, rgba(26,90,105,0.04), transparent),
+    radial-gradient(ellipse 500px 350px at 15% 40%, rgba(0,82,158,0.03), transparent);
+  pointer-events: none;
+}
+.foundation-heading {
+  font-family: var(--font-sans);
+  font-weight: 700;
+  color: var(--navy);
+  line-height: 1.25;
+  position: relative;
+}
+.foundation-sub {
+  font-family: var(--font-sans);
+  color: var(--neutral-700);
+  position: relative;
+}
+.foundation-layers {
+  display: flex;
+  position: relative;
+}
+.foundation-pyramid {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+  z-index: 2;
+}
+.foundation-col {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  position: relative;
+  z-index: 2;
+}
+.foundation-layer-card {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+.foundation-layer-card .flc-number {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  font-family: var(--font-sans);
+  font-weight: 700;
+  color: white;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.12);
+}
+.foundation-layer-card .flc-title {
+  font-family: var(--font-sans);
+  font-weight: 700;
+  line-height: 1.3;
+}
+.foundation-layer-card .flc-abbrev {
+  font-family: var(--font-mono);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.8px;
+}
+.foundation-layer-card .flc-desc {
+  font-family: var(--font-sans);
+  line-height: 1.55;
+  color: var(--neutral-900);
+}
+.foundation-layer-card .flc-desc code {
+  font-family: var(--font-mono);
+  padding: 0 3px;
+  border-radius: 2px;
+}
+.foundation-connector {
+  position: absolute;
+  z-index: 1;
+  pointer-events: none;
+}
+
+/* Layer-specific coloring */
+.flc-cli .flc-number { background: linear-gradient(135deg, var(--leaf-green), #1a4a08); }
+.flc-cli .flc-title  { color: var(--leaf-green); }
+.flc-cli .flc-abbrev { color: var(--leaf-green); }
+.flc-cli .flc-desc code { color: var(--leaf-green); background: rgba(44,103,12,0.08); }
+
+.flc-api .flc-number { background: linear-gradient(135deg, var(--cable-blue), #003d7a); }
+.flc-api .flc-title  { color: var(--cable-blue); }
+.flc-api .flc-abbrev { color: var(--cable-blue); }
+.flc-api .flc-desc code { color: var(--cable-blue); background: rgba(0,82,158,0.08); }
+
+.flc-mcp .flc-number { background: linear-gradient(135deg, var(--ocean-blue), #0e3d4a); }
+.flc-mcp .flc-title  { color: var(--ocean-blue); }
+.flc-mcp .flc-abbrev { color: var(--ocean-blue); }
+.flc-mcp .flc-desc code { color: var(--ocean-blue); background: rgba(26,90,105,0.08); }
+
+/* Highlight cards */
+.foundation-highlight-card {
+  display: flex;
+  align-items: flex-start;
+  background: var(--neutral-50);
+  border: 1px solid var(--neutral-400);
+  border-top: 3px solid var(--neutral-400);
+}
+.foundation-highlight-card .fhc-icon {
+  flex-shrink: 0;
+  border-radius: 6px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.foundation-highlight-card .fhc-text {
+  font-family: var(--font-sans);
+  color: var(--neutral-900);
+}
+.foundation-highlight-card .fhc-text strong {
+  font-weight: 700;
+  display: block;
+  margin-bottom: 2px;
+}
+.foundation-highlight-card .fhc-text code {
+  font-family: var(--font-mono);
+  padding: 0 3px;
+  border-radius: 2px;
+}
+.fhc-cli { border-top-color: var(--leaf-green); }
+.fhc-cli .fhc-icon { background: rgba(44,103,12,0.08); }
+.fhc-cli .fhc-icon svg { color: var(--leaf-green); }
+.fhc-cli .fhc-text strong { color: var(--leaf-green); }
+.fhc-cli .fhc-text code { color: var(--leaf-green); background: rgba(44,103,12,0.06); }
+
+.fhc-api { border-top-color: var(--cable-blue); }
+.fhc-api .fhc-icon { background: rgba(0,82,158,0.08); }
+.fhc-api .fhc-icon svg { color: var(--cable-blue); }
+.fhc-api .fhc-text strong { color: var(--cable-blue); }
+.fhc-api .fhc-text code { color: var(--cable-blue); background: rgba(0,82,158,0.06); }
+
+.fhc-mcp { border-top-color: var(--ocean-blue); }
+.fhc-mcp .fhc-icon { background: rgba(26,90,105,0.08); }
+.fhc-mcp .fhc-icon svg { color: var(--ocean-blue); }
+.fhc-mcp .fhc-text strong { color: var(--ocean-blue); }
+.fhc-mcp .fhc-text code { color: var(--ocean-blue); background: rgba(26,90,105,0.06); }
+
+.fhc-fast { border-top-color: var(--amber); }
+.fhc-fast .fhc-icon { background: rgba(255,193,7,0.12); }
+.fhc-fast .fhc-icon svg { color: var(--soil); }
+.fhc-fast .fhc-text strong { color: var(--soil); }
+.fhc-fast .fhc-text code { color: var(--soil); background: rgba(80,69,44,0.06); }
+
+/* ── Get Started Footer ── */
+.get-started-footer {
+  background: linear-gradient(135deg, var(--navy) 0%, var(--deep-teal) 100%);
+  position: relative;
+  overflow: hidden;
+}
+.get-started-footer::before {
+  content: '';
+  position: absolute;
+  top: -50px; right: -10px;
+  width: 200px; height: 200px;
+  background: radial-gradient(circle, rgba(95,157,174,0.15), transparent 70%);
+  border-radius: 50%;
+  pointer-events: none;
+}
+.get-started-footer::after {
+  content: '';
+  position: absolute;
+  bottom: -40px; left: 180px;
+  width: 160px; height: 160px;
+  background: radial-gradient(circle, rgba(0,82,158,0.12), transparent 70%);
+  border-radius: 50%;
+  pointer-events: none;
+}
+.gs-main { flex: 1 1 auto; min-width: 0; z-index: 1; }
+.gs-heading {
+  font-family: var(--font-sans);
+  font-weight: 700;
+  color: var(--neutral-50);
+  letter-spacing: -0.3px;
+}
+.gs-code {
+  background: rgba(254,254,254,0.07);
+  border: 1px solid rgba(254,254,254,0.1);
+  border-radius: 8px;
+  font-family: var(--font-mono);
+  white-space: pre;
+  color: #cbd5e1;
+}
+.gs-code .gs-cmd { color: #7dd3fc; font-weight: 500; }
+.gs-code .gs-dim { color: #64748b; }
+.gs-links {
+  display: flex;
+  flex-wrap: wrap;
+  z-index: 1;
+}
+.gs-link-item { text-align: center; }
+.gs-link-label {
+  font-family: var(--font-sans);
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  color: var(--seafoam);
+  margin-bottom: 2px;
+}
+.gs-link-url {
+  font-family: var(--font-sans);
+  color: rgba(254,254,254,0.6);
+}
+.gs-qr { flex-shrink: 0; z-index: 1; text-align: center; }
+.gs-qr-box {
+  background: white;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 3px 12px rgba(0,0,0,0.2);
+  overflow: hidden;
+}
+.gs-qr-label {
+  font-family: var(--font-sans);
+  color: rgba(254,254,254,0.5);
+  letter-spacing: 0.3px;
+}
+
+
+/* ═══════════════════════════════════════════
+   PART 3 — PRINT LAYOUT OVERRIDES
+   Grid, sizing, dimensions for 14400×10800px
+   ═══════════════════════════════════════════ */
+
+/* ── POSTER GRID ── */
+.poster {
+  width: 14400px;
+  max-width: 14400px;
+  height: 10800px;
+  overflow: hidden;
+  display: grid;
+  grid-template-columns: repeat(12, 1fr);
+  grid-template-rows: 1200px 2200px 2600px 3100px 1700px;
+  grid-template-areas:
+    "hd hd hd hd hd hd hd hd hd hd hd hd"
+    "ch ch ch pp pp pp pp pp pp pp pp pp"
+    "ft ft ft ft rp rp rp fn fn fn fn fn"
+    "na na na dr dr dr dr dr hr hr hr hr"
+    "na na na dr dr dr dr dr gs gs gs gs";
+  gap: 0;
+  box-shadow: none;
+}
+
+
+/* ── Hide web-only elements ── */
+.challenge-transition,
+.poster-bottom-pad,
+.flow-cue,
+.pipeline-lightbox,
+.code-lightbox,
+.print-mode-toggle,
+.gallery-section      { display: none; }
+
+
+/* ── Grid area assignments ── */
+.header              { grid-area: hd; }
+.challenge-section   { grid-area: ch; }
+.pipeline-section    { grid-area: pp; }
+.foundation-section  { grid-area: fn; }
+
+/* Features wrapper -> display:contents so children become grid items */
+.features-section                       { display: contents; }
+.features-section > .features-card:first-child { grid-area: ft; }
+.features-section > .features-card:last-child  { display: contents; }
+.get-started-footer                     { grid-area: gs; }
+
+/* Use-case row wrappers -> display:contents */
+#uc-row-45 { display: contents; }
+#uc-row-67 { display: contents; }
+/* HRRR = uc-row-45 first-child,  Drought = uc-row-45 last-child */
+#uc-row-45 > .usecase-card:first-child { grid-area: hr; }
+#uc-row-45 > .usecase-card:last-child  { grid-area: dr; }
+/* AI Narration = uc-row-67 first-child,  Repro Pipelines = uc-row-67 last-child */
+#uc-row-67 > .usecase-card:first-child { grid-area: na; }
+#uc-row-67 > .usecase-card:last-child  { grid-area: rp; }
+
+
+/* ── Shared: Section borders ── */
+.challenge-section,
+.pipeline-section,
+.foundation-section,
+.usecase-card,
+.features-section > .features-card:first-child {
+  border: 4px solid var(--neutral-400);
+  background: var(--neutral-50);
+}
+.get-started-footer {
+  border: 4px solid var(--neutral-600);
+}
+.usecase-card {
+  border-left: 14px solid var(--cable-blue);
+}
+
+
+/* ── Shared: Section tag ── */
+.section-tag { margin-bottom: 30px; }
+.section-tag span { font-size: 67px; letter-spacing: 8px; }
+.section-tag .diamond { width: 54px; height: 54px; }
+
+
+/* ═══════════════════════════════════════════
+   ROW 1 — HEADER (14400 x 1200)
+   ═══════════════════════════════════════════ */
+.header { overflow: hidden; }
+.header::after { height: 12px; }
+.header-content { min-height: 0; height: 1200px; }
+.header-left { display: none; }
+.header-right {
+  padding: 36px 300px;
+  align-items: stretch;
+  text-align: center;
+  background: radial-gradient(
+    ellipse at center 60%,
+    rgba(247,245,238,0.92) 0%,
+    rgba(247,245,238,0.75) 50%,
+    rgba(247,245,238,0.35) 100%
+  );
+}
+.header-dataviz { display: block; }
+.project-name    { font-size: 250px; margin-bottom: 0; line-height: 1.0; }
+.poster-title    { font-size: 150px; margin-bottom: 12px; line-height: 1.15; }
+.poster-subtitle { font-size: 100px; margin-bottom: 18px; }
+.author-block    { margin-bottom: 18px; gap: 12px; }
+.author-name     { font-size: 100px; }
+.author-org      { font-size: 83px; }
+.author-orcid    { font-size: 67px; }
+.orcid-dot       { font-size: 36px; width: 67px; height: 67px; }
+.badges          { gap: 48px; }
+.badge           { font-size: 54px; padding: 18px 48px 18px 18px; gap: 21px; border-radius: 36px; }
+.badge-pip       { width: 96px; height: 96px; font-size: 42px; border-radius: 28px; }
+.badge-pip svg   { width: 48px; height: 48px; }
+.badge-label     { font-size: 48px; }
+.badge-value     { font-size: 54px; }
+
+
+/* ═══════════════════════════════════════════
+   ROW 2A — CHALLENGE (3600 x 2200)
+   Row layout: text left (~55%), graphic right (~45%)
+   ═══════════════════════════════════════════ */
+.challenge-section {
+  padding: 60px;
+  overflow: hidden;
+  display: flex; flex-direction: column;
+}
+.challenge-card {
+  padding: 60px;
+  flex: 1;
+  overflow: hidden;
+  border-radius: 36px;
+  display: flex; flex-direction: column;
+}
+.challenge-frame { display: none; }
+.challenge-inner {
+  display: flex;
+  flex-direction: row;
+  gap: 60px;
+  padding: 0;
+  flex: 1;
+  align-items: stretch;
+}
+.challenge-text {
+  flex: 1 1 65%;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+}
+.challenge-heading { font-size: 120px; margin-bottom: 24px; }
+.challenge-body p  { font-size: 66px; line-height: 1.4; margin-bottom: 20px; }
+.challenge-body .tok { font-size: 58px; padding: 8px 24px; border-radius: 14px; }
+.challenge-body .em-bold { font-size: 66px; }
+.challenge-graphic {
+  flex: 0 0 30%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  max-width: none;
+}
+.challenge-graphic svg {
+  width: 100%;
+  height: auto;
+  max-width: none;
+  max-height: 100%;
+}
+
+
+/* ═══════════════════════════════════════════
+   ROW 2B — PIPELINE (10800 x 2200)
+   Grid layout: visual left, stage table right.
+   ═══════════════════════════════════════════ */
+.pipeline-section {
+  padding: 60px 72px;
+  overflow: hidden;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  grid-template-rows: auto auto auto 1fr auto;
+  column-gap: 84px;
+}
+/* Heading elements span full width */
+.pipeline-section .section-tag { grid-column: 1 / -1; grid-row: 1; }
+.pipeline-heading { font-size: 150px; margin-bottom: 18px; grid-column: 1 / -1; grid-row: 2; }
+.pipeline-sub     { font-size: 83px; margin-bottom: 24px; grid-column: 1 / -1; grid-row: 3; }
+
+/* Visual on the left — zoom 3.2 (1440×3.2 = 4608w × 1664h) */
+.pipeline-visual-wrap {
+  grid-column: 1;
+  grid-row: 4 / 6;
+  cursor: default;
+  border: none;
+  background: transparent;
+  overflow: hidden;
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+}
+.pipeline-visual-wrap .zoom-hint { display: none; }
+.pipeline-visual {
+  width: 1440px;
+  height: 520px;
+  min-height: 0;
+  transform: none;
+  zoom: 3.2;
+  flex-shrink: 0;
+}
+/* Hide animated dots — meaningless on static poster, CSS zoom misaligns them */
+.pipeline-visual .flow-bg circle[r="3.5"],
+.pipeline-visual .flow-bg circle[r="3"] { display: none; }
+
+.phase-label     { font-size: 14px; }
+.stage-circle    { width: 66px; height: 66px; }
+.stage-circle svg { width: 34px; height: 34px; }
+.stage-label-txt { font-size: 14px; }
+.stage-cli-txt   { font-size: 11px; }
+.source-icon     { width: 48px; height: 48px; }
+.source-icon svg { width: 32px; height: 32px; }
+.source-label    { font-size: 14px; }
+.callout         { display: block; }
+.callout-title   { font-size: 12px; }
+.callout-text    { font-size: 11px; line-height: 1.35; }
+.ct-tag          { font-size: 10px; padding: 3px 8px; }
+.format-pills    { display: flex; }
+.fpill           { font-size: 11px; padding: 4px 10px; border-radius: 6px; }
+.phase-summaries { display: flex; }
+.phase-summary   { font-size: 11px; line-height: 1.35; }
+
+/* Stage table + stream: children promoted to grid via display:contents */
+.pipeline-details {
+  display: contents;
+}
+.pipeline-table-wrap { grid-column: 2; grid-row: 4; align-self: start; }
+.pipeline-table    { font-size: 54px; }
+.pipeline-table th { font-size: 44px; padding: 20px 30px; }
+.pipeline-table td { padding: 20px 30px; }
+.pipeline-table .stage-num { width: 90px; }
+.pipeline-table .cli-cell  { font-size: 48px; }
+.pipeline-table .status-impl,
+.pipeline-table .status-plan,
+.pipeline-table .status-partial { font-size: 48px; }
+
+/* Streaming example — own grid row, right column */
+.stream-block { grid-column: 2; grid-row: 5; min-width: 0; align-self: end; }
+.stream-label { font-size: 44px; margin-bottom: 14px; }
+.stream-code  { font-size: 40px; padding: 28px 36px; border-radius: 20px; line-height: 1.5; white-space: pre-wrap; word-break: break-all; }
+.stream-note  { font-size: 40px; margin-top: 14px; line-height: 1.4; }
+.stream-note code { font-size: 40px; }
+
+
+/* ═══════════════════════════════════════════
+   ROW 3A — KEY FEATURES (4800 x 2600)
+   ═══════════════════════════════════════════ */
+.features-section > .features-card:first-child {
+  padding: 84px 60px 84px 84px;
+  overflow: hidden;
+  display: flex; flex-direction: column;
+  justify-content: space-between;
+}
+.features-card { border-radius: 36px; }
+.features-card h3 { font-size: 150px; margin-bottom: 48px; }
+.feat-list      { gap: 48px; flex: 1; }
+.feat-list li   { font-size: 83px; line-height: 1.45; gap: 42px; }
+.feat-dot       { width: 42px; height: 42px; margin-top: 22px; }
+.feat-list li strong { font-size: 83px; }
+.feat-list li code   { font-size: 75px; }
+.feat-meta       { margin-top: 48px; padding-top: 48px; gap: 30px; }
+.feat-meta-pill  { font-size: 67px; padding: 15px 42px; border-radius: 28px; }
+.feature-pills   { gap: 30px; margin-top: 30px; }
+.feat-pill       { font-size: 63px; padding: 18px 42px; gap: 18px; border-radius: 30px; }
+.feat-pill svg   { width: 63px; height: 63px; }
+
+
+/* ═══════════════════════════════════════════
+   ROW 3B — REPRODUCIBLE PIPELINE CONFIGS
+   (3600 x 2600, use-case card)
+   ═══════════════════════════════════════════ */
+#uc-row-67 > .usecase-card:last-child { padding: 60px 72px; }
+#uc-row-67 > .usecase-card:last-child .usecase-heading { font-size: 100px; margin-bottom: 18px; }
+#uc-row-67 > .usecase-card:last-child .usecase-desc    { font-size: 67px; margin-bottom: 24px; }
+#uc-row-67 > .usecase-card:last-child .yaml-code       { font-size: 44px; padding: 30px 48px; flex: 1; line-height: 1.35; margin-bottom: 24px; }
+#uc-row-67 > .usecase-card:last-child .yaml-code::after { font-size: 36px; }
+#uc-row-67 > .usecase-card:last-child .usecase-code    { font-size: 48px; padding: 30px 48px; line-height: 1.4; }
+#uc-row-67 > .usecase-card:last-child .usecase-code::after { font-size: 36px; }
+#uc-row-67 > .usecase-card:last-child .feature-pills   { gap: 18px; margin-top: 18px; }
+#uc-row-67 > .usecase-card:last-child .feat-pill       { font-size: 42px; padding: 12px 24px; }
+
+
+/* ═══════════════════════════════════════════
+   ROW 3C — FOUNDATION (6000 x 2600)
+   50/50 split: descriptions left, pyramid right.
+   ═══════════════════════════════════════════ */
+.foundation-section {
+  padding: 60px 60px 48px 48px;
+  overflow: hidden;
+  display: flex; flex-direction: column;
+}
+.foundation-heading { font-size: 110px; margin-bottom: 20px; }
+.foundation-sub     { font-size: 67px; margin-bottom: 24px; line-height: 1.4; }
+.foundation-layers {
+  gap: 36px;
+  flex-direction: row;
+  flex-wrap: nowrap;
+  align-items: stretch;
+  flex: 1;
+  min-height: 0;
+}
+.foundation-pyramid {
+  flex: 1 1 50%;
+  padding: 0;
+  order: 2;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.foundation-pyramid svg { width: auto; height: 1600px; }
+.foundation-col {
+  flex-direction: column;
+  gap: 18px;
+  flex-wrap: nowrap;
+  flex: 1 1 50%;
+  justify-content: center;
+  min-width: 0;
+}
+.foundation-col.col-left  { padding-right: 0; text-align: right; order: 1; }
+.foundation-col.col-right { display: none; }
+.foundation-layer-card {
+  padding: 20px 30px;
+  border-radius: 20px;
+  text-align: right;
+  flex: 0 0 auto;
+}
+.foundation-layer-card .flc-number { width: 54px; height: 54px; font-size: 28px; margin-bottom: 8px; }
+.foundation-layer-card .flc-title  { font-size: 46px; margin-bottom: 6px; }
+.foundation-layer-card .flc-abbrev { font-size: 36px; margin-bottom: 6px; }
+.foundation-layer-card .flc-desc   { font-size: 38px; line-height: 1.3; }
+.foundation-layer-card .flc-desc code { font-size: 34px; }
+.foundation-highlights {
+  display: flex;
+  gap: 24px;
+  margin-top: 24px;
+  flex: 0 0 auto;
+}
+.foundation-highlight-card { flex: 1 1 0; padding: 30px 36px; border-radius: 24px; }
+.foundation-highlight-card .fhc-icon     { width: 84px; height: 84px; }
+.foundation-highlight-card .fhc-icon svg { width: 48px; height: 48px; }
+.foundation-highlight-card .fhc-text        { font-size: 42px; line-height: 1.35; }
+.foundation-highlight-card .fhc-text strong { font-size: 46px; }
+.foundation-highlight-card .fhc-text code   { font-size: 40px; }
+
+
+/* ═══════════════════════════════════════════
+   ROWS 4-5 — USE CASE CARDS (shared)
+   ═══════════════════════════════════════════ */
+.usecase-card {
+  padding: 96px;
+  overflow: hidden;
+  margin: 0;
+  border-radius: 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+}
+.usecase-heading { font-size: 150px; margin-bottom: 36px; }
+.usecase-desc    { font-size: 100px; line-height: 1.45; margin-bottom: 54px; }
+.usecase-code    { font-size: 83px; padding: 54px 72px; line-height: 1.5; border-radius: 30px; }
+.usecase-code::after { font-size: 63px; top: 42px; right: 48px; }
+
+/* Code steps */
+.code-steps    { gap: 14px; flex: 0 0 auto; }
+.code-step     { padding: 36px 60px; }
+.step-dot      { width: 120px; height: 120px; font-size: 54px; border-radius: 30px; }
+.step-dot svg  { width: 67px; height: 67px; }
+.step-code     { font-size: 70px; line-height: 1.4; }
+.step-stage-tag { font-size: 54px; padding: 12px 30px; border-radius: 18px; }
+
+/* DAG diagram */
+.dag-wrap       { margin-bottom: 42px; gap: 21px; }
+.dag-box        { padding: 42px 54px; font-size: 75px; border-radius: 28px; gap: 36px; }
+.dag-box svg    { width: 92px; height: 92px; }
+.dag-stage-tag  { font-size: 67px; min-width: 400px; padding: 15px 36px; border-radius: 21px; }
+.dag-arrow      { padding: 12px 0; }
+.dag-arrow svg  { width: 83px; height: 83px; }
+
+/* Placeholders & captions */
+.usecase-image-wrap      { flex: 1 1 auto; min-height: 0; border-radius: 30px; display: flex; flex-direction: column; }
+.usecase-placeholder     { flex: 1 1 auto; min-height: 300px; border-radius: 30px; }
+.usecase-placeholder svg { transform: scale(3); }
+.usecase-placeholder span { font-size: 75px; }
+.usecase-caption      { font-size: 75px; margin-top: 30px; flex: 0 0 auto; }
+.usecase-caption code { font-size: 67px; }
+
+/* Flow connectors */
+.flow-connector     { padding: 21px 0; }
+.flow-connector svg { width: 83px; height: 96px; }
+
+/* Video preview (Drought) */
+.video-preview       { margin-bottom: 30px; border-radius: 30px; overflow: hidden; flex: 1 1 auto; min-height: 0; display: flex; flex-direction: column; }
+.video-thumb         { flex: 1 1 auto; min-height: 400px; }
+.video-play-btn      { width: 225px; height: 225px; }
+.video-play-btn svg  { width: 83px; height: 83px; }
+.video-bar           { padding: 36px 54px; gap: 48px; flex: 0 0 auto; }
+.video-bar-icon      { width: 92px; height: 92px; }
+.video-bar-text      { font-size: 75px; }
+
+/* Provenance callout */
+.prov-callout      { padding: 48px 63px; margin-top: 0; gap: 48px; border-radius: 28px; flex: 0 0 auto; }
+.prov-callout svg  { width: 83px; height: 83px; }
+.prov-callout p    { font-size: 75px; line-height: 1.45; }
+.prov-callout code { font-size: 67px; }
+
+/* ── AI Narration card (3 cols × 2 rows = narrow & tall) ── */
+#uc-row-67 > .usecase-card:first-child {
+  border-left-color: var(--ocean-blue);
+  padding: 72px 72px 54px;
+}
+#uc-row-67 > .usecase-card:first-child .usecase-heading { font-size: 110px; margin-bottom: 18px; }
+#uc-row-67 > .usecase-card:first-child .usecase-desc    { font-size: 67px; margin-bottom: 30px; }
+
+/* User intent bubble */
+.user-intent-bubble { padding: 36px 48px; margin-bottom: 30px; border-radius: 30px; }
+.user-intent-bubble::before { display: none; }
+.user-intent-avatar     { width: 84px; height: 84px; }
+.user-intent-avatar svg { width: 48px; height: 48px; }
+.user-intent-name { font-size: 48px; }
+.user-intent-text { font-size: 58px; line-height: 1.4; }
+
+/* Swarm diagram — sized to leave room for bottom content */
+.swarm-diagram     { margin-bottom: 24px; flex: 0 0 auto; display: flex; align-items: center; justify-content: center; }
+.swarm-diagram svg { height: 1600px; width: auto; }
+
+/* Narration chain */
+.narration-chain { margin-top: 24px; gap: 18px; }
+.nc-pill  { font-size: 48px; padding: 16px 36px; border-radius: 30px; }
+.nc-arrow { font-size: 54px; }
+
+/* Guard callout */
+.guard-callout      { padding: 30px 42px; margin-top: 24px; border-radius: 24px; gap: 30px; }
+.guard-callout svg  { width: 60px; height: 60px; }
+.guard-callout p    { font-size: 50px; line-height: 1.4; }
+.guard-callout code { font-size: 46px; }
+
+/* Section labels inside narration card */
+#uc-row-67 > .usecase-card:first-child > div[style*="text-transform"] {
+  font-size: 42px !important;
+  margin-top: 24px !important;
+  margin-bottom: 12px !important;
+}
+
+/* Code blocks in narration card (override inline styles) */
+#uc-row-67 > .usecase-card:first-child .usecase-code {
+  font-size: 42px !important;
+  padding: 30px 42px !important;
+  line-height: 1.4 !important;
+  border-radius: 24px;
+  margin-bottom: 12px !important;
+}
+#uc-row-67 > .usecase-card:first-child .usecase-code::after { font-size: 30px; }
+
+/* Provider table (AI Narration) */
+.provider-table-wrap { margin-top: 24px; margin-bottom: 24px; }
+.provider-table    { font-size: 50px; border-radius: 24px; }
+.provider-table th { font-size: 42px; padding: 24px 36px; }
+.provider-table td { padding: 24px 36px; }
+.prov-name  { font-size: 50px; }
+.prov-usage { font-size: 42px; }
+
+/* YAML code (Repro Pipelines) */
+.yaml-code { font-size: 75px; padding: 54px 72px; line-height: 1.45; margin-bottom: 42px; border-radius: 30px; }
+.yaml-code::after { font-size: 58px; }
+
+/* Code zoom (disable web interaction) */
+.code-zoom-wrap { cursor: default; overflow: visible; height: auto; }
+.code-zoom-wrap .zoom-hint { display: none; }
+.code-zoom-inner { transform: none; }
+
+
+/* ═══════════════════════════════════════════
+   ROW 5 — GET STARTED (4800 x 1700)
+   ═══════════════════════════════════════════ */
+.get-started-footer {
+  margin: 0;
+  padding: 72px 84px;
+  gap: 54px;
+  border-radius: 0;
+  display: flex;
+  align-items: flex-start;
+  flex-direction: column;
+  justify-content: space-between;
+}
+.get-started-footer::before,
+.get-started-footer::after { display: none; }
+.get-started-footer .code-zoom-wrap { display: contents; }
+.get-started-footer .code-zoom-inner {
+  display: flex; gap: 84px; align-items: flex-start; width: 100%;
+}
+.get-started-footer .gs-heading { font-size: 133px; margin-bottom: 42px; color: var(--neutral-50); }
+.gs-code       { font-size: 83px; padding: 54px 72px; margin-bottom: 48px; line-height: 1.5; border-radius: 30px; }
+.gs-cmd        { font-size: 83px; }
+.gs-dim        { font-size: 75px; }
+.gs-links           { gap: 24px; flex-wrap: wrap; }
+.gs-badge           { padding: 18px 42px 18px 18px; border-radius: 48px; gap: 18px;
+                      text-decoration: none; color: var(--neutral-50);
+                      background: rgba(254,254,254,0.08); border: 3px solid rgba(254,254,254,0.18); }
+.gs-badge-pip       { width: 63px; height: 63px; border-radius: 16px; }
+.gs-badge-pip svg   { width: 36px; height: 36px; }
+.gs-badge-pip.pip-pypi   { font-size: 30px; }
+.gs-badge-pip.pip-doi    { font-size: 30px; }
+.gs-badge-pip.pip-gh     { background: var(--neutral-900); }
+.gs-badge-pip.pip-docs   { background: var(--ocean-blue); }
+.gs-badge-pip.pip-assist { background: var(--seafoam); }
+.gs-badge-label     { font-size: 42px; color: rgba(254,254,254,0.55); }
+.gs-badge-value     { font-size: 54px; font-weight: 600; color: var(--neutral-50); }
+.gs-qr         { display: flex; flex-direction: column; align-items: center; }
+.gs-qr-box     { width: 540px; height: 540px; border-radius: 42px; }
+.gs-qr-box img { width: 460px; height: 460px; }
+.gs-qr-label   { font-size: 63px; }
+
+
+/* ═══════════════════════════════════════════
+   PRINT MEDIA — for actual printing
+   ═══════════════════════════════════════════ */
+@media print {
+  body   { background: none; padding: 0; margin: 0; }
+  .poster { box-shadow: none; }
+}


### PR DESCRIPTION
This pull request introduces a new script for building the conference poster HTML from section fragments, along with supporting print layout files. The script automates the assembly of web and print versions of the poster, ensuring the print version is self-contained and excludes the gallery section. The changes also add new HTML fragment files for the print layout.

New poster build script:

* Added `build_poster.py` in `poster/scripts` to generate both web (`zyra-poster.html`) and print (`zyra-poster-print.html`) versions of the conference poster, handling section assembly and layout differences.

Print layout HTML fragments:

* Added `_head-print.html` to define the document head for the print version, including metadata and font links.
* Added `_body-open-print.html` to start the poster body for the print layout.
* Added `_footer-print.html` to close the print layout HTML document.