### PR TITLE
fix(ci): include print poster in GitHub Pages deployment

### DIFF
--- a/.github/workflows/docs-pages.yaml
+++ b/.github/workflows/docs-pages.yaml
@@ -1,0 +1,65 @@
+# SPDX-License-Identifier: Apache-2.0
+name: Build and Deploy Docs (GitHub Pages)
+
+on:
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          lfs: true
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Install Sphinx and MyST
+        run: |
+          python -m pip install --upgrade pip
+          # Install Sphinx, MyST (Markdown support), and RTD theme
+          pip install sphinx myst-parser sphinx_rtd_theme
+          pip install -e .
+
+      - name: Build Sphinx HTML
+        working-directory: docs
+        run: sphinx-build -b html source build
+
+      - name: Build poster and copy into docs output
+        run: |
+          python poster/scripts/build_poster.py
+          mkdir -p docs/build/poster
+          cp poster/html/zyra-poster.html docs/build/poster/
+          cp poster/html/zyra-poster-print.html docs/build/poster/
+          cp poster/html/*.png docs/build/poster/
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/build
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
The docs-pages workflow only copied zyra-poster.html to the Pages build output, causing a 404 at /poster/zyra-poster-print.html. Add the print version to the copy step so both poster variants are deployed.

https://claude.ai/code/session_011meoUUDwixYjLmaELedgsn