### PR TITLE
fix: hide header logo on the right for improved layout

### DIFF
--- a/poster/html/zyra-poster.html
+++ b/poster/html/zyra-poster.html
@@ -2282,6 +2282,7 @@ RESPONSIVE / PRINT
 .challenge-section, .pipeline-section, .usecase-row, .gallery-section, .features-section, .foundation-section { padding-left: 28px; padding-right: 28px; }
 .header-content { flex-direction: column; }
 .header-left { display: none; }
+.header-logo-right { display: none; }
 .header-right { padding: 24px 28px 36px; }
 .project-name { font-size: 42px; }
 .poster-title { font-size: 22px; }

--- a/poster/sections/_styles.css
+++ b/poster/sections/_styles.css
@@ -2270,6 +2270,7 @@ RESPONSIVE / PRINT
 .challenge-section, .pipeline-section, .usecase-row, .gallery-section, .features-section, .foundation-section { padding-left: 28px; padding-right: 28px; }
 .header-content { flex-direction: column; }
 .header-left { display: none; }
+.header-logo-right { display: none; }
 .header-right { padding: 24px 28px 36px; }
 .project-name { font-size: 42px; }
 .poster-title { font-size: 22px; }


### PR DESCRIPTION
This pull request makes a minor adjustment to the poster layout by hiding the `.header-logo-right` element in both the HTML and CSS files. This change ensures that the logo on the right side of the header is not displayed, likely to improve visual consistency or responsiveness.