### PR TITLE
Update sync-upstream workflow to use app token Signed-off-by: Eric Hackathorn <erichackathorn@gmail.com>

### DIFF
--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -40,6 +40,13 @@ jobs:
       MIRROR_URL: https://github.com/Hackshaven/zyra.git
 
     steps:
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Configure Git
         run: |
           git config --global user.name "zyra-sync-bot"
@@ -71,7 +78,7 @@ jobs:
 
       - name: Push selected branches (and optional tags) to mirror/*  (with LFS)
         env:
-          GITHUB_TOKEN: ${{ github.token }}   # built-in token for same-repo pushes
+          APP_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           set -euo pipefail
 
@@ -85,8 +92,8 @@ jobs:
 
           # git filter-repo drops remotes; recreate them now
           git remote add origin "$UPSTREAM_URL" || git remote set-url origin "$UPSTREAM_URL"
-          git remote add mirror "https://x-access-token:${GITHUB_TOKEN}@${MIRROR_URL#https://}" || \
-            git remote set-url mirror "https://x-access-token:${GITHUB_TOKEN}@${MIRROR_URL#https://}"
+          git remote add mirror "https://x-access-token:${APP_TOKEN}@${MIRROR_URL#https://}" || \
+            git remote set-url mirror "https://x-access-token:${APP_TOKEN}@${MIRROR_URL#https://}"
 
           # Ensure latest & prune deleted refs from upstream
           git fetch --prune origin
@@ -125,4 +132,3 @@ jobs:
       - name: Summary
         if: always()
         run: echo "Mirror (workflows stripped + LFS mirrored) complete at $(date -u +"%Y-%m-%dT%H:%M:%SZ")."
-        


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow in `.github/workflows/sync-upstream.yml` to use a GitHub App token for authentication when pushing to the mirror repository, instead of the default `GITHUB_TOKEN`. This change improves security and flexibility for repository synchronization.

**Authentication improvements:**

* Added a step to generate a GitHub App token using `actions/create-github-app-token@v1`, leveraging `APP_ID` and `APP_PRIVATE_KEY` secrets for authentication.
* Updated environment variable usage in the push step to use `APP_TOKEN` instead of the built-in `GITHUB_TOKEN`.
* Changed remote URL configuration for the mirror repository to use the new `APP_TOKEN` for authentication.

**Minor cleanup:**

* Removed trailing whitespace after the summary step for improved formatting.