### PR TITLE
Update MIRROR_URL in sync-upstream workflow

### DIFF
--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -37,7 +37,7 @@ jobs:
       FORCE: ${{ github.event.inputs.force || 'true' }}
       UPSTREAM_URL: https://github.com/NOAA-GSL/zyra.git
       # Use canonical (case-stable) URL to avoid redirect noise
-      MIRROR_URL: https://github.com/Hackshaven/zyra.git
+      MIRROR_URL: https://github.com/zyra-project/zyra.git
 
     steps:
       - name: Generate app token


### PR DESCRIPTION
This pull request makes a small update to the GitHub Actions workflow configuration. The change updates the mirror repository URL to use the canonical organization and repository name.

* [`.github/workflows/sync-upstream.yml`](diffhunk://#diff-930c31adbfe446d796136dd9ebe2d531ecabcd0636f4d27192bd1e860a788309L40-R40): Changed `MIRROR_URL` from `https://github.com/Hackshaven/zyra.git` to `https://github.com/zyra-project/zyra.git` to use the canonical repository URL.