### PR TITLE
Add downstream-to-upstream new-issue relay to the issue sync

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -108,16 +108,34 @@ This workflow keeps issues synchronized between the upstream [`NOAA-GSL/zyra`](h
 - This allows work to happen in either repository while keeping status in sync.
 - **Requires write access**: The `SYNC_PAT_ORG` token must have write access to upstream issues for this to work.
 
+#### Downstream → Upstream (new-issue relay)
+- Issues **created in this repo** (e.g. by AI-agent sessions or downstream
+  contributors) do not sync automatically. To relay one upstream, a
+  collaborator applies the **`relay-upstream`** label.
+- The workflow then creates the upstream twin (with a provenance header
+  crediting the downstream author), stamps the downstream issue with the
+  sync marker + `upstream-sync` label, and the status relay above covers
+  the pair from then on.
+- The label is the security gate: only collaborators can apply labels, so
+  drive-by issues can't forge sync markers into upstream writes.
+- A manual sweep exists for backfill: run the workflow with direction
+  `relay-new` to relay every open `relay-upstream`-labeled issue that has
+  no upstream twin yet.
+- Uses the same `SYNC_PAT_ORG` write access as the status relay.
+
 ### Labels
 
 | Label | Purpose |
 |-------|---------|
 | `upstream-sync` | Identifies issues mirrored from upstream. **Do not remove this label** from synced issues. |
+| `relay-upstream` | Collaborator-applied: relay this downstream-originated issue to upstream. |
 
-**Setup:** Create the label before the first sync run:
+**Setup:** Create the labels before the first sync run:
 ```bash
 gh label create "upstream-sync" --repo zyra-project/zyra \
   --description "Issue mirrored from NOAA-GSL/zyra" --color "1d76db"
+gh label create "relay-upstream" --repo zyra-project/zyra \
+  --description "Relay this downstream issue to NOAA-GSL/zyra" --color "0e8a16"
 ```
 
 ### Issue Body Format

--- a/.github/workflows/sync-github-issues.yml
+++ b/.github/workflows/sync-github-issues.yml
@@ -388,7 +388,7 @@ jobs:
 
       - name: Relay labeled downstream issues to upstream
         if: >-
-          (github.event_name == 'issues' && github.event.action == 'labeled' && github.event.label.name == 'relay-upstream') ||
+          (github.event_name == 'issues' && github.event.action == 'labeled' && github.event.label.name == env.RELAY_LABEL) ||
           (github.event_name == 'workflow_dispatch' && github.event.inputs.direction == 'relay-new')
         uses: actions/github-script@v7
         env:
@@ -445,6 +445,21 @@ jobs:
               });
               await sleep(1000);
 
+              // Issues are always created open; if the downstream issue is
+              // already closed (relay label applied post-close), propagate
+              // the state now — no status event will fire to correct it
+              // (PR #237 Copilot review).
+              if (issue.state === 'closed') {
+                await github.request('PATCH /repos/{owner}/{repo}/issues/{issue_number}', {
+                  owner: upstreamOwner,
+                  repo: upstreamRepo,
+                  issue_number: upIssue.number,
+                  state: 'closed',
+                  headers: upstreamAuth
+                });
+                await sleep(1000);
+              }
+
               // Stamp the downstream issue: marker at the top of the body,
               // sync label so the status paths pick it up.
               const upstreamLink = `https://github.com/${upstreamOwner}/${upstreamRepo}/issues/${upIssue.number}`;
@@ -468,10 +483,12 @@ jobs:
             // workflow_dispatch relay-new: sweep for labeled-but-unrelayed issues
             console.log('🔄 Sweeping for relay-labeled issues without an upstream twin');
             if (dryRun) console.log('🧪 DRY RUN MODE - no changes will be made');
+            // state 'all': a closed labeled issue still deserves its twin
+            // (created closed via the state propagation above).
             const labeled = (await github.paginate(github.rest.issues.listForRepo, {
               owner: downstreamOwner,
               repo: downstreamRepo,
-              state: 'open',
+              state: 'all',
               labels: relayLabel,
               per_page: 100
             })).filter(i => !i.pull_request);

--- a/.github/workflows/sync-github-issues.yml
+++ b/.github/workflows/sync-github-issues.yml
@@ -4,12 +4,18 @@ name: Sync GitHub Issues (NOAA-GSL ↔ zyra-project)
 # By default, only syncs upstream→downstream (one-way mirror).
 # Bidirectional sync (downstream→upstream) requires SYNC_PAT_ORG to have write
 # access to the upstream repository's issues.
+#
+# Downstream-originated issues can be relayed upstream by applying the
+# "relay-upstream" label (collaborators only — that permission gate is the
+# security model). The relay creates the upstream twin, stamps the downstream
+# issue with the sync marker + label, and the existing status sync covers it
+# from then on.
 
 on:
   schedule:
     - cron: "*/30 * * * *"     # every 30 minutes
   issues:
-    types: [closed, reopened]
+    types: [closed, reopened, labeled]
   workflow_dispatch:
     inputs:
       direction:
@@ -21,6 +27,7 @@ on:
           - upstream-to-downstream
           - both
           - downstream-to-upstream
+          - relay-new
       dry_run:
         description: "Dry run (no changes made)"
         required: false
@@ -41,6 +48,7 @@ env:
   DOWNSTREAM_OWNER: zyra-project
   DOWNSTREAM_REPO: zyra
   SYNC_LABEL: "upstream-sync"
+  RELAY_LABEL: "relay-upstream"
   UPSTREAM_MARKER: "<!-- upstream-issue:"
 
 jobs:
@@ -242,9 +250,14 @@ jobs:
                 return;
               }
 
-              // Security: verify issue was created by the sync bot (prevents forged markers)
-              if (issue.user?.login !== 'github-actions[bot]') {
-                console.log(`📌 Issue author '${issue.user?.login}' is not github-actions[bot], skipping for security`);
+              // Security: verify the marker is trustworthy. Bot-authored issues
+              // wrote their own marker; human-authored issues qualify only when
+              // a collaborator applied the relay label (label permissions are
+              // the gate — non-collaborators can't apply labels, so a forged
+              // marker in a drive-by issue never reaches the PATCH below).
+              const hasRelayLabel = issue.labels?.some(l => (typeof l === 'string' ? l : l.name) === process.env.RELAY_LABEL);
+              if (issue.user?.login !== 'github-actions[bot]' && !hasRelayLabel) {
+                console.log(`📌 Issue author '${issue.user?.login}' is not github-actions[bot] and issue is not relay-labeled, skipping for security`);
                 return;
               }
 
@@ -372,6 +385,101 @@ jobs:
             }
 
             console.log(`✅ Downstream → Upstream sync complete: ${synced} issues updated`);
+
+      - name: Relay labeled downstream issues to upstream
+        if: >-
+          (github.event_name == 'issues' && github.event.action == 'labeled' && github.event.label.name == 'relay-upstream') ||
+          (github.event_name == 'workflow_dispatch' && github.event.inputs.direction == 'relay-new')
+        uses: actions/github-script@v7
+        env:
+          ORG_TOKEN: ${{ secrets.SYNC_PAT_ORG }}
+          DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const upstreamOwner = process.env.UPSTREAM_OWNER;
+            const upstreamRepo = process.env.UPSTREAM_REPO;
+            const downstreamOwner = process.env.DOWNSTREAM_OWNER;
+            const downstreamRepo = process.env.DOWNSTREAM_REPO;
+            const syncLabel = process.env.SYNC_LABEL;
+            const relayLabel = process.env.RELAY_LABEL;
+            const upstreamMarker = process.env.UPSTREAM_MARKER;
+            const dryRun = process.env.DRY_RUN === 'true';
+            const orgToken = process.env.ORG_TOKEN;
+
+            const upstreamAuth = { authorization: `token ${orgToken}` };
+            const sleep = (ms) => new Promise(resolve => setTimeout(resolve, ms));
+            const markerRe = new RegExp(`${upstreamMarker.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\s*(\\d+)\\s*-->`);
+
+            // Relay one downstream-originated issue upstream: create the
+            // upstream twin, then stamp the downstream issue with the sync
+            // marker + label so the existing status sync owns it from here.
+            // Idempotent: a marker already in the body means already relayed
+            // (or already an upstream mirror) — skip.
+            async function relay(issue) {
+              if (issue.pull_request) {
+                console.log(`📌 #${issue.number} is a pull request, skipping`);
+                return;
+              }
+              if (issue.body?.match(markerRe)) {
+                console.log(`📌 #${issue.number} already carries an upstream marker, skipping`);
+                return;
+              }
+              if (issue.user?.login === 'github-actions[bot]') {
+                console.log(`📌 #${issue.number} is bot-authored (an upstream mirror), skipping`);
+                return;
+              }
+
+              console.log(`⬆️ Relaying downstream #${issue.number}: "${issue.title}"`);
+              if (dryRun) return;
+
+              const downstreamLink = `https://github.com/${downstreamOwner}/${downstreamRepo}/issues/${issue.number}`;
+              const provenance = `> ⬆️ **Relayed from downstream:** [${downstreamOwner}/${downstreamRepo}#${issue.number}](${downstreamLink}) (author: @${issue.user?.login})\n>\n> _Status changes sync between the two copies._\n\n---\n\n`;
+
+              const { data: upIssue } = await github.request('POST /repos/{owner}/{repo}/issues', {
+                owner: upstreamOwner,
+                repo: upstreamRepo,
+                title: issue.title,
+                body: provenance + (issue.body || '_No description provided._'),
+                headers: upstreamAuth
+              });
+              await sleep(1000);
+
+              // Stamp the downstream issue: marker at the top of the body,
+              // sync label so the status paths pick it up.
+              const upstreamLink = `https://github.com/${upstreamOwner}/${upstreamRepo}/issues/${upIssue.number}`;
+              const stamp = `> 🔗 **Relayed to upstream:** [${upstreamOwner}/${upstreamRepo}#${upIssue.number}](${upstreamLink})\n\n${upstreamMarker} ${upIssue.number} -->\n\n---\n\n`;
+              await github.rest.issues.update({
+                owner: downstreamOwner,
+                repo: downstreamRepo,
+                issue_number: issue.number,
+                body: stamp + (issue.body || ''),
+                labels: [...new Set([syncLabel, relayLabel, ...issue.labels.map(l => typeof l === 'string' ? l : l.name)])]
+              });
+              await sleep(1000);
+              console.log(`✅ Relayed #${issue.number} → upstream #${upIssue.number}`);
+            }
+
+            if (context.eventName === 'issues') {
+              await relay(context.payload.issue);
+              return;
+            }
+
+            // workflow_dispatch relay-new: sweep for labeled-but-unrelayed issues
+            console.log('🔄 Sweeping for relay-labeled issues without an upstream twin');
+            if (dryRun) console.log('🧪 DRY RUN MODE - no changes will be made');
+            const labeled = (await github.paginate(github.rest.issues.listForRepo, {
+              owner: downstreamOwner,
+              repo: downstreamRepo,
+              state: 'open',
+              labels: relayLabel,
+              per_page: 100
+            })).filter(i => !i.pull_request);
+            for (const issue of labeled) {
+              await relay(issue);
+              await sleep(1000);
+            }
+            console.log(`✅ Relay sweep complete over ${labeled.length} labeled issue(s)`);
 
       - name: Summary
         if: always()


### PR DESCRIPTION
## What & why

The mirror's sync machinery covered three of four quadrants: code and upstream issues flow **down**, PRs and issue *statuses* flow **up** — but issues **born downstream** (AI-agent sessions, downstream contributors) had no path to NOAA-GSL/zyra. This closes the quadrant by extending the existing `sync-github-issues.yml` (no new workflow file) with a **label-gated relay**:

- A collaborator applies the **`relay-upstream`** label to a downstream issue → the workflow creates the upstream twin (provenance header crediting the downstream author), stamps the downstream issue with the existing sync marker + `upstream-sync` label, and the **existing status relay owns the pair from then on** (closed-is-closed both ways).
- **Security model: label permissions are the gate.** Only collaborators can apply labels, so the forged-marker attack the old bot-author check defends against stays closed — and that check is relaxed to accept relay-labeled human-authored issues so status sync covers them.
- **Idempotent**: an existing upstream marker means already-relayed (or an upstream mirror) — skipped. A `workflow_dispatch` direction `relay-new` sweeps labeled-but-unrelayed issues for backfill.
- **No new credentials** — reuses `SYNC_PAT_ORG`'s upstream issue-write access, the same permission the status relay already requires.

Targets `main` per the branch model: mirror machinery stays downstream (and Actions only runs workflows from the default branch); `mirror/*` remains untouched zyra source.

## Historical context

Commit `e9e34e4` (Feb 2026) narrowed the sync default to one-way — the recorded motive was **unverified PAT permissions**, not policy. That caveat carries into this change (see rollout).

## Rollout / canary

1. Merge, then create the labels (commands in the workflows README):
   `upstream-sync` (if absent) and `relay-upstream`.
2. Apply `relay-upstream` to **one** issue (#232 suggested) and watch the run.
   - Twin appears at NOAA-GSL → the other staged issues (#233–#236) are four label clicks.
   - "lacks write access" in the log → `SYNC_PAT_ORG` needs upstream issue scope; nothing breaks, and the prefilled `issues/new` fallback links still work meanwhile.

## Verification

- YAML validated; workflow README documents the new direction, both labels, and the backfill dispatch.
- Relay step runs only on `labeled` events for the specific label (or explicit dispatch) — the scheduled path is unchanged.
- One consideration to hold when reviewing: relayed content posts upstream **under the PAT owner's identity** — the label click is a collaborator vouching for that content at NOAA-GSL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G1ZEw6d1yXepDb819YVNRP

---
_Generated by [Claude Code](https://claude.ai/code/session_01G1ZEw6d1yXepDb819YVNRP)_