### PR TITLE
Fix --extent parsing for Domain API list expansion across visualize commands

### DIFF
--- a/src/zyra/visualization/cli_animate.py
+++ b/src/zyra/visualization/cli_animate.py
@@ -19,6 +19,9 @@ def handle_animate(ns) -> int:
     if getattr(ns, "trace", False):
         os.environ["ZYRA_SHELL_TRACE"] = "1"
     configure_logging_from_env()
+    from zyra.visualization.cli_utils import resolve_extent
+
+    ns.extent = resolve_extent(ns)
     # Batch mode for animate: --inputs with --output-dir
     if getattr(ns, "inputs", None):
         if not ns.output_dir:

--- a/src/zyra/visualization/cli_contour.py
+++ b/src/zyra/visualization/cli_contour.py
@@ -21,6 +21,9 @@ def handle_contour(ns) -> int:
     if getattr(ns, "trace", False):
         os.environ["ZYRA_SHELL_TRACE"] = "1"
     configure_logging_from_env()
+    from zyra.visualization.cli_utils import resolve_extent
+
+    ns.extent = resolve_extent(ns)
     # Batch mode
     if getattr(ns, "inputs", None):
         outdir = getattr(ns, "output_dir", None)

--- a/src/zyra/visualization/cli_heatmap.py
+++ b/src/zyra/visualization/cli_heatmap.py
@@ -22,6 +22,9 @@ def handle_heatmap(ns) -> int:
     if getattr(ns, "trace", False):
         os.environ["ZYRA_SHELL_TRACE"] = "1"
     configure_logging_from_env()
+    from zyra.visualization.cli_utils import resolve_extent
+
+    ns.extent = resolve_extent(ns)
     # Batch mode: --inputs with --output-dir
     if getattr(ns, "inputs", None):
         outdir = getattr(ns, "output_dir", None)

--- a/src/zyra/visualization/cli_interactive.py
+++ b/src/zyra/visualization/cli_interactive.py
@@ -17,6 +17,9 @@ def handle_interactive(ns) -> int:
     if getattr(ns, "trace", False):
         os.environ["ZYRA_SHELL_TRACE"] = "1"
     configure_logging_from_env()
+    from zyra.visualization.cli_utils import resolve_extent
+
+    ns.extent = resolve_extent(ns)
     # Lazy import to reduce startup cost when visualization isn't used
     from zyra.visualization.interactive_manager import InteractiveManager
 

--- a/src/zyra/visualization/cli_register.py
+++ b/src/zyra/visualization/cli_register.py
@@ -30,12 +30,18 @@ def register_cli(subparsers: Any) -> None:
         "--basemap",
         help="Basemap (path, bare image name, or pkg:ref)",
     )
+    # extent flags use action="extend" with default=None: the Domain API
+    # runner expands list args as repeated flags (--extent w --extent e ...)
+    # which nargs=4 cannot parse, and argparse's extend action appends to
+    # a list default. Handlers apply the full-globe default and validate
+    # length via cli_utils.resolve_extent.
     p_hm.add_argument(
         "--extent",
-        nargs=4,
+        nargs="+",
         type=float,
-        default=[-180, 180, -90, 90],
-        help="west east south north",
+        action="extend",
+        default=None,
+        help="west east south north (default: -180 180 -90 90)",
     )
     p_hm.add_argument(
         "--output",
@@ -137,10 +143,11 @@ def register_cli(subparsers: Any) -> None:
     p_ct.add_argument("--basemap", help="Basemap (path, bare image name, or pkg:ref)")
     p_ct.add_argument(
         "--extent",
-        nargs=4,
+        nargs="+",
         type=float,
-        default=[-180, 180, -90, 90],
-        help="west east south north",
+        action="extend",
+        default=None,
+        help="west east south north (default: -180 180 -90 90)",
     )
     p_ct.add_argument(
         "--output",
@@ -235,7 +242,14 @@ def register_cli(subparsers: Any) -> None:
     p_vec.add_argument("--u")
     p_vec.add_argument("--v")
     p_vec.add_argument("--basemap", help="Basemap (path, bare image name, or pkg:ref)")
-    p_vec.add_argument("--extent", nargs=4, type=float, default=[-180, 180, -90, 90])
+    p_vec.add_argument(
+        "--extent",
+        nargs="+",
+        type=float,
+        action="extend",
+        default=None,
+        help="west east south north (default: -180 180 -90 90)",
+    )
     p_vec.add_argument("--width", type=int, default=1024)
     p_vec.add_argument("--height", type=int, default=512)
     p_vec.add_argument("--dpi", type=int, default=96)
@@ -287,7 +301,14 @@ def register_cli(subparsers: Any) -> None:
     p_anim.add_argument("--scale")
     p_anim.add_argument("--color", default="#333333")
     p_anim.add_argument("--basemap", help="Basemap (path, bare image name, or pkg:ref)")
-    p_anim.add_argument("--extent", nargs=4, type=float, default=[-180, 180, -90, 90])
+    p_anim.add_argument(
+        "--extent",
+        nargs="+",
+        type=float,
+        action="extend",
+        default=None,
+        help="west east south north (default: -180 180 -90 90)",
+    )
     p_anim.add_argument("--width", type=int, default=1024)
     p_anim.add_argument("--height", type=int, default=512)
     p_anim.add_argument("--dpi", type=int, default=96)
@@ -399,7 +420,14 @@ def register_cli(subparsers: Any) -> None:
     p_int.add_argument("--timestamp-loc", default="lower_right")
     p_int.add_argument("--tiles", default="OpenStreetMap")
     p_int.add_argument("--zoom", type=int, default=3)
-    p_int.add_argument("--extent", nargs=4, type=float, default=[-180, 180, -90, 90])
+    p_int.add_argument(
+        "--extent",
+        nargs="+",
+        type=float,
+        action="extend",
+        default=None,
+        help="west east south north (default: -180 180 -90 90)",
+    )
     p_int.add_argument("--width", type=int, default=1024)
     p_int.add_argument("--height", type=int, default=512)
     p_int.add_argument("--output", required=True)

--- a/src/zyra/visualization/cli_utils.py
+++ b/src/zyra/visualization/cli_utils.py
@@ -63,6 +63,27 @@ def load_data_array(
     raise ValueError("Unsupported input file; use .nc, .nc4, or .npy")
 
 
+#: Full-globe default for ``--extent`` (west, east, south, north).
+DEFAULT_EXTENT = (-180.0, 180.0, -90.0, 90.0)
+
+
+def resolve_extent(ns) -> list[float]:
+    """Validate and default the ``--extent`` value on a parsed namespace.
+
+    The extent flags are declared with ``action="extend"``/``nargs="+"``
+    so both the CLI spelling (``--extent w e s n``) and the Domain API's
+    repeated-flag expansion (``--extent w --extent e ...``) accumulate
+    into one list; the parser can no longer enforce the length, so it is
+    validated here. Returns the full-globe default when unset.
+    """
+    extent = getattr(ns, "extent", None)
+    if extent is None:
+        return list(DEFAULT_EXTENT)
+    if len(extent) != 4:
+        raise SystemExit("--extent takes exactly 4 values: west east south north")
+    return [float(v) for v in extent]
+
+
 def features_from_ns(ns) -> list[str] | None:
     """Build a features list from argparse namespace flags.
 

--- a/src/zyra/visualization/cli_utils.py
+++ b/src/zyra/visualization/cli_utils.py
@@ -9,7 +9,7 @@ try:  # Prefer standard library importlib.resources
 except Exception:  # pragma: no cover - fallback for very old Python
     import importlib_resources  # type: ignore
 
-from zyra.visualization.styles import MAP_STYLES
+from zyra.visualization.styles import DEFAULT_EXTENT, MAP_STYLES
 
 
 def load_data_array(
@@ -63,10 +63,6 @@ def load_data_array(
     raise ValueError("Unsupported input file; use .nc, .nc4, or .npy")
 
 
-#: Full-globe default for ``--extent`` (west, east, south, north).
-DEFAULT_EXTENT = (-180.0, 180.0, -90.0, 90.0)
-
-
 def resolve_extent(ns) -> list[float]:
     """Validate and default the ``--extent`` value on a parsed namespace.
 
@@ -74,13 +70,21 @@ def resolve_extent(ns) -> list[float]:
     so both the CLI spelling (``--extent w e s n``) and the Domain API's
     repeated-flag expansion (``--extent w --extent e ...``) accumulate
     into one list; the parser can no longer enforce the length, so it is
-    validated here. Returns the full-globe default when unset.
+    validated here. Returns the full-globe default
+    (``styles.DEFAULT_EXTENT``) when unset.
+
+    Exits with code 2 (message on stderr via logging) on a wrong-length
+    value: the Domain API executor coerces ``SystemExit.code`` with
+    ``int()``, so the code must be numeric, never a message string.
     """
     extent = getattr(ns, "extent", None)
     if extent is None:
         return list(DEFAULT_EXTENT)
     if len(extent) != 4:
-        raise SystemExit("--extent takes exactly 4 values: west east south north")
+        import logging
+
+        logging.error("--extent takes exactly 4 values: west east south north")
+        raise SystemExit(2)
     return [float(v) for v in extent]
 
 

--- a/src/zyra/visualization/cli_vector.py
+++ b/src/zyra/visualization/cli_vector.py
@@ -22,6 +22,9 @@ def handle_vector(ns) -> int:
     if getattr(ns, "trace", False):
         os.environ["ZYRA_SHELL_TRACE"] = "1"
     configure_logging_from_env()
+    from zyra.visualization.cli_utils import resolve_extent
+
+    ns.extent = resolve_extent(ns)
     # Batch mode
     if getattr(ns, "inputs", None):
         outdir = getattr(ns, "output_dir", None)

--- a/src/zyra/wizard/zyra_capabilities.json
+++ b/src/zyra/wizard/zyra_capabilities.json
@@ -2850,14 +2850,8 @@
       "--var": "Variable name for NetCDF inputs",
       "--basemap": "Basemap (path, bare image name, or pkg:ref)",
       "--extent": {
-        "help": "west east south north",
-        "type": "float",
-        "default": [
-          -180,
-          180,
-          -90,
-          90
-        ]
+        "help": "west east south north (default: -180 180 -90 90)",
+        "type": "float"
       },
       "--output": {
         "help": "Output PNG path (required when using --input; for --inputs use --output-dir)",
@@ -3080,14 +3074,8 @@
       "--var": "Variable name for NetCDF inputs",
       "--basemap": "Basemap (path, bare image name, or pkg:ref)",
       "--extent": {
-        "help": "west east south north",
-        "type": "float",
-        "default": [
-          -180,
-          180,
-          -90,
-          90
-        ]
+        "help": "west east south north (default: -180 180 -90 90)",
+        "type": "float"
       },
       "--output": {
         "help": "Output PNG path (required for single --input; when using --inputs, prefer --output-dir)",
@@ -3410,14 +3398,8 @@
       "--v": "",
       "--basemap": "Basemap (path, bare image name, or pkg:ref)",
       "--extent": {
-        "help": "",
-        "type": "float",
-        "default": [
-          -180,
-          180,
-          -90,
-          90
-        ]
+        "help": "west east south north (default: -180 180 -90 90)",
+        "type": "float"
       },
       "--width": {
         "help": "",
@@ -3658,14 +3640,8 @@
       },
       "--basemap": "Basemap (path, bare image name, or pkg:ref)",
       "--extent": {
-        "help": "",
-        "type": "float",
-        "default": [
-          -180,
-          180,
-          -90,
-          90
-        ]
+        "help": "west east south north (default: -180 180 -90 90)",
+        "type": "float"
       },
       "--width": {
         "help": "",
@@ -4034,14 +4010,8 @@
         "default": 3
       },
       "--extent": {
-        "help": "",
-        "type": "float",
-        "default": [
-          -180,
-          180,
-          -90,
-          90
-        ]
+        "help": "west east south north (default: -180 180 -90 90)",
+        "type": "float"
       },
       "--width": {
         "help": "",
@@ -4336,14 +4306,8 @@
       "--var": "Variable name for NetCDF inputs",
       "--basemap": "Basemap (path, bare image name, or pkg:ref)",
       "--extent": {
-        "help": "west east south north",
-        "type": "float",
-        "default": [
-          -180,
-          180,
-          -90,
-          90
-        ]
+        "help": "west east south north (default: -180 180 -90 90)",
+        "type": "float"
       },
       "--output": {
         "help": "Output PNG path (required when using --input; for --inputs use --output-dir)",
@@ -4538,14 +4502,8 @@
       "--var": "Variable name for NetCDF inputs",
       "--basemap": "Basemap (path, bare image name, or pkg:ref)",
       "--extent": {
-        "help": "west east south north",
-        "type": "float",
-        "default": [
-          -180,
-          180,
-          -90,
-          90
-        ]
+        "help": "west east south north (default: -180 180 -90 90)",
+        "type": "float"
       },
       "--output": {
         "help": "Output PNG path (required for single --input; when using --inputs, prefer --output-dir)",
@@ -4840,14 +4798,8 @@
       "--v": "",
       "--basemap": "Basemap (path, bare image name, or pkg:ref)",
       "--extent": {
-        "help": "",
-        "type": "float",
-        "default": [
-          -180,
-          180,
-          -90,
-          90
-        ]
+        "help": "west east south north (default: -180 180 -90 90)",
+        "type": "float"
       },
       "--width": {
         "help": "",
@@ -5061,14 +5013,8 @@
       },
       "--basemap": "Basemap (path, bare image name, or pkg:ref)",
       "--extent": {
-        "help": "",
-        "type": "float",
-        "default": [
-          -180,
-          180,
-          -90,
-          90
-        ]
+        "help": "west east south north (default: -180 180 -90 90)",
+        "type": "float"
       },
       "--width": {
         "help": "",
@@ -5402,14 +5348,8 @@
         "default": 3
       },
       "--extent": {
-        "help": "",
-        "type": "float",
-        "default": [
-          -180,
-          180,
-          -90,
-          90
-        ]
+        "help": "west east south north (default: -180 180 -90 90)",
+        "type": "float"
       },
       "--width": {
         "help": "",

--- a/src/zyra/wizard/zyra_capabilities/visualize.json
+++ b/src/zyra/wizard/zyra_capabilities/visualize.json
@@ -110,14 +110,8 @@
       },
       "--basemap": "Basemap (path, bare image name, or pkg:ref)",
       "--extent": {
-        "help": "",
-        "type": "float",
-        "default": [
-          -180,
-          180,
-          -90,
-          90
-        ]
+        "help": "west east south north (default: -180 180 -90 90)",
+        "type": "float"
       },
       "--width": {
         "help": "",
@@ -417,14 +411,8 @@
       "--var": "Variable name for NetCDF inputs",
       "--basemap": "Basemap (path, bare image name, or pkg:ref)",
       "--extent": {
-        "help": "west east south north",
-        "type": "float",
-        "default": [
-          -180,
-          180,
-          -90,
-          90
-        ]
+        "help": "west east south north (default: -180 180 -90 90)",
+        "type": "float"
       },
       "--output": {
         "help": "Output PNG path (required for single --input; when using --inputs, prefer --output-dir)",
@@ -603,14 +591,8 @@
       "--var": "Variable name for NetCDF inputs",
       "--basemap": "Basemap (path, bare image name, or pkg:ref)",
       "--extent": {
-        "help": "west east south north",
-        "type": "float",
-        "default": [
-          -180,
-          180,
-          -90,
-          90
-        ]
+        "help": "west east south north (default: -180 180 -90 90)",
+        "type": "float"
       },
       "--output": {
         "help": "Output PNG path (required when using --input; for --inputs use --output-dir)",
@@ -839,14 +821,8 @@
         "default": 3
       },
       "--extent": {
-        "help": "",
-        "type": "float",
-        "default": [
-          -180,
-          180,
-          -90,
-          90
-        ]
+        "help": "west east south north (default: -180 180 -90 90)",
+        "type": "float"
       },
       "--width": {
         "help": "",
@@ -1213,14 +1189,8 @@
       "--v": "",
       "--basemap": "Basemap (path, bare image name, or pkg:ref)",
       "--extent": {
-        "help": "",
-        "type": "float",
-        "default": [
-          -180,
-          180,
-          -90,
-          90
-        ]
+        "help": "west east south north (default: -180 180 -90 90)",
+        "type": "float"
       },
       "--width": {
         "help": "",
@@ -1434,14 +1404,8 @@
       },
       "--basemap": "Basemap (path, bare image name, or pkg:ref)",
       "--extent": {
-        "help": "",
-        "type": "float",
-        "default": [
-          -180,
-          180,
-          -90,
-          90
-        ]
+        "help": "west east south north (default: -180 180 -90 90)",
+        "type": "float"
       },
       "--width": {
         "help": "",
@@ -1776,14 +1740,8 @@
       "--var": "Variable name for NetCDF inputs",
       "--basemap": "Basemap (path, bare image name, or pkg:ref)",
       "--extent": {
-        "help": "west east south north",
-        "type": "float",
-        "default": [
-          -180,
-          180,
-          -90,
-          90
-        ]
+        "help": "west east south north (default: -180 180 -90 90)",
+        "type": "float"
       },
       "--output": {
         "help": "Output PNG path (required for single --input; when using --inputs, prefer --output-dir)",
@@ -1973,14 +1931,8 @@
       "--var": "Variable name for NetCDF inputs",
       "--basemap": "Basemap (path, bare image name, or pkg:ref)",
       "--extent": {
-        "help": "west east south north",
-        "type": "float",
-        "default": [
-          -180,
-          180,
-          -90,
-          90
-        ]
+        "help": "west east south north (default: -180 180 -90 90)",
+        "type": "float"
       },
       "--output": {
         "help": "Output PNG path (required when using --input; for --inputs use --output-dir)",
@@ -2237,14 +2189,8 @@
         "default": 3
       },
       "--extent": {
-        "help": "",
-        "type": "float",
-        "default": [
-          -180,
-          180,
-          -90,
-          90
-        ]
+        "help": "west east south north (default: -180 180 -90 90)",
+        "type": "float"
       },
       "--width": {
         "help": "",
@@ -2672,14 +2618,8 @@
       "--v": "",
       "--basemap": "Basemap (path, bare image name, or pkg:ref)",
       "--extent": {
-        "help": "",
-        "type": "float",
-        "default": [
-          -180,
-          180,
-          -90,
-          90
-        ]
+        "help": "west east south north (default: -180 180 -90 90)",
+        "type": "float"
       },
       "--width": {
         "help": "",

--- a/tests/visualization/test_extent_flags.py
+++ b/tests/visualization/test_extent_flags.py
@@ -63,12 +63,16 @@ def test_default_is_none_not_mutated(cmd):
     assert ns.extent is None
 
 
-def test_resolve_extent_defaults_and_validates():
+def test_resolve_extent_defaults_and_validates(caplog):
     assert resolve_extent(SimpleNamespace(extent=None)) == list(DEFAULT_EXTENT)
     assert resolve_extent(SimpleNamespace()) == list(DEFAULT_EXTENT)
     assert resolve_extent(SimpleNamespace(extent=[1, 2, 3, 4])) == [1.0, 2.0, 3.0, 4.0]
-    with pytest.raises(SystemExit, match="exactly 4 values"):
+    # The exit code must be numeric — the Domain API executor coerces
+    # SystemExit.code with int(), so a message string would crash it.
+    with caplog.at_level("ERROR"), pytest.raises(SystemExit) as excinfo:
         resolve_extent(SimpleNamespace(extent=[1.0, 2.0, 3.0]))
+    assert excinfo.value.code == 2
+    assert "exactly 4 values" in caplog.text
 
 
 def test_api_argv_round_trips_extent():

--- a/tests/visualization/test_extent_flags.py
+++ b/tests/visualization/test_extent_flags.py
@@ -1,0 +1,85 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for --extent flag parsing across visualization commands.
+
+The Domain API's argv builder expands list args as repeated flags
+(``--extent w --extent e ...``), which the previous ``nargs=4``
+declarations could not parse — extent-cropped renders via the API
+never worked. The flags now use ``action="extend"`` so both spellings
+accumulate, with length validation in ``resolve_extent``.
+"""
+
+import argparse
+from types import SimpleNamespace
+
+import pytest
+
+from zyra.visualization.cli_register import register_cli
+from zyra.visualization.cli_utils import DEFAULT_EXTENT, resolve_extent
+
+EXTENT_COMMANDS = ["heatmap", "contour", "vector", "animate", "interactive"]
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="visualize")
+    register_cli(parser.add_subparsers(dest="cmd"))
+    return parser
+
+
+def _required_stub(cmd: str) -> list[str]:
+    # Minimal required args per command so parse_args succeeds.
+    stubs = {
+        "heatmap": ["--input", "x.nc"],
+        "contour": ["--input", "x.nc", "--output", "o.png"],
+        "vector": ["--input", "x.nc"],
+        "animate": [],
+        "interactive": ["--input", "x.nc", "--output", "o.html"],
+    }
+    return stubs[cmd]
+
+
+@pytest.mark.parametrize("cmd", EXTENT_COMMANDS)
+def test_single_flag_spelling_parses(cmd):
+    ns = _parser().parse_args(
+        [cmd, *_required_stub(cmd), "--extent", "-120", "-60", "20", "55"]
+    )
+    assert ns.extent == [-120.0, -60.0, 20.0, 55.0]
+
+
+@pytest.mark.parametrize("cmd", EXTENT_COMMANDS)
+def test_repeated_flag_spelling_accumulates(cmd):
+    # The Domain API expansion: one flag occurrence per value.
+    argv = [cmd, *_required_stub(cmd)]
+    for v in ("-120", "-60", "20", "55"):
+        argv += ["--extent", v]
+    ns = _parser().parse_args(argv)
+    assert ns.extent == [-120.0, -60.0, 20.0, 55.0]
+
+
+@pytest.mark.parametrize("cmd", EXTENT_COMMANDS)
+def test_default_is_none_not_mutated(cmd):
+    # extend appends to list defaults; default must therefore be None
+    # (resolve_extent supplies the full globe).
+    ns = _parser().parse_args([cmd, *_required_stub(cmd)])
+    assert ns.extent is None
+
+
+def test_resolve_extent_defaults_and_validates():
+    assert resolve_extent(SimpleNamespace(extent=None)) == list(DEFAULT_EXTENT)
+    assert resolve_extent(SimpleNamespace()) == list(DEFAULT_EXTENT)
+    assert resolve_extent(SimpleNamespace(extent=[1, 2, 3, 4])) == [1.0, 2.0, 3.0, 4.0]
+    with pytest.raises(SystemExit, match="exactly 4 values"):
+        resolve_extent(SimpleNamespace(extent=[1.0, 2.0, 3.0]))
+
+
+def test_api_argv_round_trips_extent():
+    # End-to-end for the API path: args dict -> executor argv -> parser.
+    from zyra.api.workers.executor import _args_dict_to_argv
+
+    argv = _args_dict_to_argv(
+        "visualize",
+        "heatmap",
+        {"input": "x.nc", "output": "o.png", "extent": [-120, -60, 20, 55]},
+    )
+    assert argv[:2] == ["visualize", "heatmap"]
+    ns = _parser().parse_args(argv[1:])
+    assert ns.extent == [-120.0, -60.0, 20.0, 55.0]


### PR DESCRIPTION
Implements NOAA-GSL/zyra#296 (staged downstream as #242): the Domain API's argv builder expands list args as repeated flags (`--extent w --extent e ...`), which the `nargs=4` declarations on heatmap/contour/vector/animate/interactive could not parse — **extent-cropped renders via `POST /visualize` have never worked**.

## Fix (the option-b sweep from the issue)

- All five `--extent` declarations move to `action="extend"` + `nargs="+"`, so both the CLI spelling (`--extent w e s n`) and the API's repeated-flag expansion accumulate into one list. No executor change; genuinely repeatable flags (e.g. `--credential`) keep working.
- argparse's `extend` action appends to list defaults, so the full-globe default moves out of the parsers into a shared `resolve_extent` helper in `cli_utils` — which also owns the length==4 validation with a clear error (`--extent takes exactly 4 values`) instead of a deep TypeError.
- Each handler resolves once at entry (`ns.extent = resolve_extent(ns)`); every downstream `ns.extent` use is untouched, keeping the diff surgical.

## Verification

- 17 new tests in `tests/visualization/test_extent_flags.py`: both spellings parse for all five commands (parametrized), the parser default stays `None` (guarding the extend-appends-to-default footgun), resolver defaulting/validation, and an **API round-trip** — args dict → `_args_dict_to_argv` → real parser → correct extent — proving the previously-broken path end to end.
- Wizard manifests regenerated (extent help/default text). No API schema change (`extent` was already `list[float]` with a length validator), so the OpenAPI snapshot is untouched.
- `ruff` (pinned 0.6.4) clean; visualization + api + misc suites pass. The 2 failures in `tests/misc/test_cli_smoke_streaming.py` are pre-existing in this environment (identical with the diff stashed — GRIB2 streaming, unrelated).

Prior art: NOAA-GSL#287 fixed the identical expansion bug in `pipeline_runner` (YAML path); NOAA-GSL#295 used this same extend pattern for `process reproject`'s bounds flags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G1ZEw6d1yXepDb819YVNRP

---
_Generated by [Claude Code](https://claude.ai/code/session_01G1ZEw6d1yXepDb819YVNRP)_