### PR TITLE
Skip relay git work on closed PRs

### DIFF
--- a/.github/workflows/relay-to-org.yml
+++ b/.github/workflows/relay-to-org.yml
@@ -98,6 +98,7 @@ jobs:
         run: echo "RELAY_BASE=${{ steps.ctx.outputs.relay_base }}" >> "$GITHUB_ENV"
 
       - name: Checkout PR head
+        if: ${{ steps.ctx.outputs.is_closed != 'true' }}
         uses: actions/checkout@v4
         with:
           repository: ${{ steps.ctx.outputs.head_repo }}
@@ -106,12 +107,14 @@ jobs:
           persist-credentials: false
 
       - name: Configure Git
+        if: ${{ steps.ctx.outputs.is_closed != 'true' }}
         run: |
           git config user.name "relay-bot"
           git config user.email "relay-bot@example.com"
           git config advice.skippedCherryPicks false
 
       - name: Ensure upstream base exists
+        if: ${{ steps.ctx.outputs.is_closed != 'true' }}
         env:
           ORG_TOKEN: ${{ secrets.SYNC_PAT_ORG }}
         run: |
@@ -120,6 +123,7 @@ jobs:
             (echo "::error ::${{ env.ORG_OWNER }}/${{ env.ORG_REPO }}:${{ env.RELAY_BASE }} not found" && exit 1)
 
       - name: Add upstream and fetch base
+        if: ${{ steps.ctx.outputs.is_closed != 'true' }}
         env:
           ORG_TOKEN: ${{ secrets.SYNC_PAT_ORG }}
         run: |
@@ -130,6 +134,7 @@ jobs:
           git fetch origin "${{ steps.ctx.outputs.base_ref }}"
 
       - name: Rebase onto upstream base (auto-resolve infra/docs/LFS)
+        if: ${{ steps.ctx.outputs.is_closed != 'true' }}
         id: rebase
         shell: bash
         run: |


### PR DESCRIPTION
## Problem

The merge-upstream-then-close-downstream wrap-up flow makes the relay workflow fail noisily on every landed PR. On the close event it still runs its checkout/rebase steps, tries to rebase the branch's commits onto an upstream staging that **already contains them** (they were just merged), hits "patch already applied" conflicts, posts a misleading ❌ "Action: rebase and push again" comment on the closed PR, and fails the run. Observed on both the #241 and #243 wrap-ups (runs at 21:40 and 22:02 UTC Jul 23).

## Fix

Gate the five git-side steps (Checkout PR head, Configure Git, Ensure upstream base, Add upstream and fetch base, Rebase) on `steps.ctx.outputs.is_closed != 'true'`. A close event now skips straight to the "Close matching org PR" step, which is pure API and needs no git state. Open-PR behavior (create/update/rebase/conflict-comment) is unchanged.

## Verification

- YAML validated.
- The push/upsert steps already carried this same `is_closed` condition — this extends the existing pattern to the steps that feed them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G1ZEw6d1yXepDb819YVNRP

---
_Generated by [Claude Code](https://claude.ai/code/session_01G1ZEw6d1yXepDb819YVNRP)_