### PR TITLE
Mirror CPython exit semantics for non-int SystemExit codes in run_cli

### DIFF
--- a/src/zyra/api/workers/executor.py
+++ b/src/zyra/api/workers/executor.py
@@ -461,11 +461,26 @@ def run_cli(stage: str, command: str, args: dict[str, Any]) -> RunResult:
         try:
             code = cli_main(argv)
             if not isinstance(code, int):
-                # Defensive: CLI returns int per contract; coerce otherwise
-                code = int(code) if code is not None else 0
+                # Defensive: CLI returns int per contract; mirror CPython's
+                # exit-status semantics otherwise (message -> stderr, exit 1).
+                if code is None:
+                    code = 0
+                else:
+                    print(str(code), file=sys.stderr)
+                    code = 1
         except SystemExit as exc:
-            # Many CLI funcs raise SystemExit; extract code
-            code = int(getattr(exc, "code", 1) or 0)
+            # Many CLI funcs raise SystemExit; extract code. A large share
+            # of raise sites use the `raise SystemExit("message")` idiom,
+            # where .code IS the message string — coercing that with int()
+            # crashed the handler and swallowed the message. CPython prints
+            # non-int codes to stderr and exits 1; do the same so the
+            # message surfaces in the captured stderr / API error payload.
+            code = getattr(exc, "code", 1)
+            if code is None:
+                code = 0
+            elif not isinstance(code, int):
+                print(str(code), file=sys.stderr)
+                code = 1
         except Exception as exc:  # pragma: no cover
             # Log full traceback for visibility; still capture stderr for response mapping
             import logging as _logging

--- a/tests/api/test_executor_systemexit.py
+++ b/tests/api/test_executor_systemexit.py
@@ -7,6 +7,8 @@ the code with ``int()``, crashing the handler and losing the message.
 It now mirrors CPython: non-int codes print to stderr and exit 1.
 """
 
+from __future__ import annotations
+
 import os
 import tempfile
 

--- a/tests/api/test_executor_systemexit.py
+++ b/tests/api/test_executor_systemexit.py
@@ -1,0 +1,61 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Executor handling of SystemExit codes (issue: string-code crash).
+
+~105 CLI raise sites use the ``raise SystemExit("message")`` idiom,
+where ``.code`` is the message string. The executor previously coerced
+the code with ``int()``, crashing the handler and losing the message.
+It now mirrors CPython: non-int codes print to stderr and exit 1.
+"""
+
+import os
+import tempfile
+
+from fastapi.testclient import TestClient
+
+from zyra.api.server import app
+from zyra.api.workers.executor import run_cli
+
+
+def test_systemexit_string_message_surfaces_as_exit_1():
+    # compose-video's missing-frames check is a real string-raise site.
+    result = run_cli(
+        "visualize",
+        "compose-video",
+        {"frames": "/definitely/not/a/dir", "output": "/tmp/out.mp4"},
+    )
+    assert result.exit_code == 1
+    assert "Frames directory not found" in result.stderr
+
+
+def test_systemexit_integer_code_preserved():
+    # argparse rejects unknown flags with SystemExit(2); the integer
+    # path must pass through unchanged.
+    result = run_cli(
+        "visualize",
+        "compose-video",
+        {"frames": "/tmp", "output": "/tmp/out.mp4", "bogus_flag": "1"},
+    )
+    assert result.exit_code == 2
+
+
+def test_api_surfaces_message_as_execution_error(monkeypatch):
+    monkeypatch.setenv("DATAVIZHUB_API_KEY", "k")
+    client = TestClient(app)
+    with tempfile.TemporaryDirectory() as td:
+        missing = os.path.join(td, "no_frames_here")
+        r = client.post(
+            "/v1/visualize",
+            json={
+                "tool": "compose-video",
+                "args": {"frames": missing, "output": os.path.join(td, "o.mp4")},
+                "options": {"sync": True},
+            },
+            headers={"X-API-Key": "k"},
+        )
+    assert r.status_code == 200
+    js = r.json()
+    assert js.get("status") == "error"
+    assert js.get("exit_code") == 1
+    err = js.get("error") or {}
+    assert err.get("type") == "execution_error"
+    assert "Frames directory not found" in (err.get("message") or "")


### PR DESCRIPTION
Implements NOAA-GSL/zyra#298 (staged downstream as #245): the Domain API executor coerced `SystemExit.code` with `int()`, but ~105 CLI raise sites use the standard `raise SystemExit("message")` idiom where `.code` *is* the message string — so any of those paths reached via the API crashed the except handler with an unrelated `ValueError` and lost the user-facing message.

## Fix (boundary, not a 105-site sweep)

Handle non-int codes exactly the way CPython's interpreter does: print the message to stderr (captured into the API's error payload) and exit 1. The same guard replaces the adjacent `int()` coercion of non-int *return values*. Integer and `None` codes flow through bit-for-bit as before. Sweeping the raise sites instead was rejected in the issue: huge churn, regression risk, and the idiom is legitimate Python that new code will keep using — the boundary fix covers all current and future sites.

## Verification

Three tests in `tests/api/test_executor_systemexit.py`, matching the issue's acceptance sketch:
- `run_cli` through a real string-raise site (compose-video's missing-frames check) → exit 1 with the message on captured stderr
- argparse's `SystemExit(2)` (unknown flag) → integer code preserved
- Wire-level: `POST /visualize` through the FastAPI test client → clean `execution_error` with exit_code 1 and the original message, instead of the previous handler crash

Full `tests/api` suite passes (the 2 failures in `test_domain_visualize_happy.py` are pre-existing in this environment, verified on the untouched base). `ruff` (pinned 0.6.4) clean. No API schema change — OpenAPI snapshot untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G1ZEw6d1yXepDb819YVNRP

---
_Generated by [Claude Code](https://claude.ai/code/session_01G1ZEw6d1yXepDb819YVNRP)_