### PR TITLE
Crop the viewport to --extent in heatmap/contour/vector managers

### DIFF
--- a/src/zyra/visualization/contour_manager.py
+++ b/src/zyra/visualization/contour_manager.py
@@ -16,6 +16,7 @@ from .styles import (
     FIGURE_DPI,
     MAP_STYLES,
     apply_matplotlib_style,
+    apply_view_extent,
     timestamp_anchor,
 )
 
@@ -213,7 +214,7 @@ class ContourManager(Renderer):
                     facecolor="#00000066", edgecolor="none", boxstyle="round,pad=0.2"
                 ),
             )
-        ax.set_global()
+        apply_view_extent(ax, self.extent)
         ax.axis("off")
         fig.subplots_adjust(left=0, right=1, top=1, bottom=0)
         self._fig = fig

--- a/src/zyra/visualization/heatmap_manager.py
+++ b/src/zyra/visualization/heatmap_manager.py
@@ -16,6 +16,7 @@ from .styles import (
     FIGURE_DPI,
     MAP_STYLES,
     apply_matplotlib_style,
+    apply_view_extent,
     timestamp_anchor,
 )
 
@@ -197,7 +198,7 @@ class HeatmapManager(Renderer):
                     facecolor="#00000066", edgecolor="none", boxstyle="round,pad=0.2"
                 ),
             )
-        ax.set_global()
+        apply_view_extent(ax, self.extent)
         ax.axis("off")
         fig.subplots_adjust(left=0, right=1, top=1, bottom=0)
         self._fig = fig

--- a/src/zyra/visualization/styles.py
+++ b/src/zyra/visualization/styles.py
@@ -25,6 +25,22 @@ FONT_SIZES: dict[str, int] = {
 }
 
 
+def apply_view_extent(ax, extent) -> None:
+    """Crop a GeoAxes view to ``extent``; keep the global view for the default.
+
+    ``extent`` is ``[west, east, south, north]`` in PlateCarree degrees.
+    Regional extents previously rendered as a small stamp on a world map
+    because the managers hardcoded ``ax.set_global()`` — for regional
+    products (e.g. HRRR) that wastes almost the whole frame.
+    """
+    if list(extent) == list(DEFAULT_EXTENT):
+        ax.set_global()
+        return
+    import cartopy.crs as ccrs
+
+    ax.set_extent(list(extent), crs=ccrs.PlateCarree())
+
+
 def apply_matplotlib_style():
     """Apply minimal Matplotlib rcParams for consistent styling.
 

--- a/src/zyra/visualization/vector_field_manager.py
+++ b/src/zyra/visualization/vector_field_manager.py
@@ -13,7 +13,13 @@ from zyra.utils.geo_utils import detect_crs_from_path, warn_if_mismatch
 
 from .base import Renderer
 from .basemap import add_basemap_cartopy, add_basemap_tile
-from .styles import DEFAULT_EXTENT, FIGURE_DPI, MAP_STYLES, apply_matplotlib_style
+from .styles import (
+    DEFAULT_EXTENT,
+    FIGURE_DPI,
+    MAP_STYLES,
+    apply_matplotlib_style,
+    apply_view_extent,
+)
 
 
 class VectorFieldManager(Renderer):
@@ -213,7 +219,7 @@ class VectorFieldManager(Renderer):
                 transform=(data_transform or ccrs.PlateCarree()),
                 linewidths=0.5,
             )
-        ax.set_global()
+        apply_view_extent(ax, self.extent)
         ax.axis("off")
         fig.subplots_adjust(left=0, right=1, top=1, bottom=0)
         self._fig = fig

--- a/src/zyra/visualization/vector_particles_manager.py
+++ b/src/zyra/visualization/vector_particles_manager.py
@@ -16,7 +16,13 @@ from zyra.utils.geo_utils import detect_crs_from_path, warn_if_mismatch
 
 from .base import Renderer
 from .basemap import add_basemap_cartopy
-from .styles import DEFAULT_EXTENT, FIGURE_DPI, MAP_STYLES, apply_matplotlib_style
+from .styles import (
+    DEFAULT_EXTENT,
+    FIGURE_DPI,
+    MAP_STYLES,
+    apply_matplotlib_style,
+    apply_view_extent,
+)
 
 
 @dataclass
@@ -261,7 +267,7 @@ class VectorParticlesManager(Renderer):
                 alpha=0.9,
                 linewidths=0,
             )
-            ax.set_global()
+            apply_view_extent(ax, self.extent)
             ax.axis("off")
             fig.subplots_adjust(left=0, right=1, top=1, bottom=0)
 

--- a/tests/visualization/test_view_extent.py
+++ b/tests/visualization/test_view_extent.py
@@ -1,0 +1,47 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Regional --extent must crop the viewport, not stamp a world map.
+
+The managers hardcoded ``ax.set_global()``, so a regional render (e.g.
+an HRRR CONUS product) wasted ~96% of the frame on empty world map.
+``apply_view_extent`` crops to the configured extent and preserves the
+global view for the full-globe default.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+pytest.importorskip("cartopy")
+import matplotlib  # noqa: E402
+
+matplotlib.use("Agg")
+
+from zyra.visualization.heatmap_manager import HeatmapManager  # noqa: E402
+from zyra.visualization.styles import DEFAULT_EXTENT  # noqa: E402
+
+CONUS = [-134.12, -60.89, 21.12, 52.63]
+
+
+def _render(extent):
+    mgr = HeatmapManager(extent=extent)
+    data = np.random.rand(20, 40).astype("float32")
+    fig = mgr.render(data)
+    assert fig is not None
+    geo_axes = [a for a in fig.axes if hasattr(a, "get_extent")]
+    assert geo_axes, "no GeoAxes found on rendered figure"
+    return geo_axes[0].get_extent()
+
+
+def test_regional_extent_crops_viewport():
+    west, east, south, north = _render(CONUS)
+    assert west == pytest.approx(CONUS[0], abs=0.5)
+    assert east == pytest.approx(CONUS[1], abs=0.5)
+    assert south == pytest.approx(CONUS[2], abs=0.5)
+    assert north == pytest.approx(CONUS[3], abs=0.5)
+
+
+def test_default_extent_stays_global():
+    west, east, south, north = _render(list(DEFAULT_EXTENT))
+    assert east - west == pytest.approx(360.0, abs=1.0)
+    assert north - south == pytest.approx(180.0, abs=1.0)

--- a/tests/visualization/test_view_extent.py
+++ b/tests/visualization/test_view_extent.py
@@ -32,17 +32,20 @@ pytestmark = pytest.mark.skipif(
     reason="Cartopy-heavy tests require cartopy and opt-in (DATAVIZHUB_RUN_CARTOPY_TESTS=1)",
 )
 
-import matplotlib  # noqa: E402
+# Heavy imports stay out of module scope so collection succeeds in
+# environments without matplotlib/cartopy (skipif gates the tests, but
+# module-level imports would still run at collection time).
+if not _skip_cartopy_heavy:  # pragma: no cover - environment-dependent
+    import matplotlib
 
-matplotlib.use("Agg")
-
-from zyra.visualization.heatmap_manager import HeatmapManager  # noqa: E402
-from zyra.visualization.styles import DEFAULT_EXTENT  # noqa: E402
+    matplotlib.use("Agg")
 
 CONUS = [-134.12, -60.89, 21.12, 52.63]
 
 
 def _render(extent):
+    from zyra.visualization.heatmap_manager import HeatmapManager
+
     mgr = HeatmapManager(extent=extent)
     data = np.random.rand(20, 40).astype("float32")
     fig = mgr.render(data)
@@ -61,6 +64,8 @@ def test_regional_extent_crops_viewport():
 
 
 def test_default_extent_stays_global():
+    from zyra.visualization.styles import DEFAULT_EXTENT
+
     west, east, south, north = _render(list(DEFAULT_EXTENT))
     assert east - west == pytest.approx(360.0, abs=1.0)
     assert north - south == pytest.approx(180.0, abs=1.0)

--- a/tests/visualization/test_view_extent.py
+++ b/tests/visualization/test_view_extent.py
@@ -9,10 +9,29 @@ global view for the full-globe default.
 
 from __future__ import annotations
 
+import os
+
 import numpy as np
 import pytest
 
-pytest.importorskip("cartopy")
+# Skip Cartopy-heavy tests unless explicitly enabled (repo convention,
+# matching tests/visualization/test_managers.py).
+_has_cartopy = False
+try:  # pragma: no cover - import guard
+    import cartopy  # noqa: F401
+
+    _has_cartopy = True
+except Exception:
+    pass
+
+_skip_cartopy_heavy = (not _has_cartopy) or os.environ.get(
+    "DATAVIZHUB_RUN_CARTOPY_TESTS"
+) != "1"
+pytestmark = pytest.mark.skipif(
+    _skip_cartopy_heavy,
+    reason="Cartopy-heavy tests require cartopy and opt-in (DATAVIZHUB_RUN_CARTOPY_TESTS=1)",
+)
+
 import matplotlib  # noqa: E402
 
 matplotlib.use("Agg")


### PR DESCRIPTION
Implements NOAA-GSL/zyra#300 (staged downstream as #247): the visualization managers hardcoded `ax.set_global()`, so a regional `--extent` placed the data correctly but rendered it as a small stamp on a full world map — an HRRR CONUS product wasted ~96% of the frame.

## Fix

New `apply_view_extent(ax, extent)` helper in `styles.py`: crops the GeoAxes to the configured extent via `ax.set_extent(..., crs=PlateCarree())`, and calls `ax.set_global()` unchanged when the extent equals the full-globe default — default renders are pixel-identical. Applied in `heatmap_manager`, `contour_manager`, `vector_field_manager`, and `vector_particles_manager`. The `sos` renderer (`plot_manager`) is deliberately untouched: full-globe is its spec.

## Verification

- Rendered live against real data: HRRR 18Z composite reflectivity warped to its native bbox now fills the frame edge-to-edge (before/after images in downstream #247's discussion context — the difference is ~4% useful pixels vs 100%).
- `tests/visualization/test_view_extent.py`: asserts the actual GeoAxes viewport after render — regional CONUS extent crops to within 0.5°, default extent spans 360×180.
- Full `tests/visualization` suite passes; `ruff` (pinned 0.6.4) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G1ZEw6d1yXepDb819YVNRP

---
_Generated by [Claude Code](https://claude.ai/code/session_01G1ZEw6d1yXepDb819YVNRP)_