### PR TITLE
Wire the URL/idx-aware reader into process GRIB handlers

### DIFF
--- a/src/zyra/cli.py
+++ b/src/zyra/cli.py
@@ -302,45 +302,14 @@ def _normalize_group_name(name: str) -> str:
 def _read_bytes(
     path_or_url: str, *, idx_pattern: str | None = None, unsigned: bool = False
 ) -> bytes:
-    # stdin
-    if path_or_url == "-":
-        return sys.stdin.buffer.read()
+    # Shared implementation lives in io_utils (URL/S3 + .idx subsetting);
+    # this wrapper keeps the historical SystemExit convention of this module.
+    from zyra.utils.io_utils import read_bytes_any
 
-    p = Path(path_or_url)
-    if p.exists():
-        return p.read_bytes()
-
-    # HTTP(S)
-    if path_or_url.startswith("http://") or path_or_url.startswith("https://"):
-        try:
-            from zyra.connectors.backends import http as http_backend
-            from zyra.utils.grib import idx_to_byteranges
-
-            if idx_pattern:
-                lines = http_backend.get_idx_lines(path_or_url)
-                ranges = idx_to_byteranges(lines, idx_pattern)
-                return http_backend.download_byteranges(path_or_url, ranges.keys())
-            return http_backend.fetch_bytes(path_or_url)
-        except Exception as exc:  # pragma: no cover - optional dep
-            raise SystemExit(f"Failed to fetch from URL: {exc}") from exc
-
-    # S3
-    if path_or_url.startswith("s3://"):
-        try:
-            from zyra.connectors.backends import s3 as s3_backend
-            from zyra.utils.grib import idx_to_byteranges
-
-            if idx_pattern:
-                lines = s3_backend.get_idx_lines(path_or_url, unsigned=unsigned)
-                ranges = idx_to_byteranges(lines, idx_pattern)
-                return s3_backend.download_byteranges(
-                    path_or_url, None, ranges.keys(), unsigned=unsigned
-                )
-            return s3_backend.fetch_bytes(path_or_url, unsigned=unsigned)
-        except Exception as exc:  # pragma: no cover - optional dep
-            raise SystemExit(f"Failed to fetch from S3: {exc}") from exc
-
-    raise SystemExit(f"Input not found or unsupported scheme: {path_or_url}")
+    try:
+        return read_bytes_any(path_or_url, idx_pattern=idx_pattern, unsigned=unsigned)
+    except RuntimeError as exc:
+        raise SystemExit(str(exc)) from exc
 
 
 def cmd_decode_grib2(args: argparse.Namespace) -> int:

--- a/src/zyra/processing/__init__.py
+++ b/src/zyra/processing/__init__.py
@@ -773,6 +773,11 @@ def register_cli(subparsers: Any) -> None:
         "--backend", default="cfgrib", choices=["cfgrib", "pygrib", "wgrib2"]
     )
     p_ext.add_argument(
+        "--unsigned",
+        action="store_true",
+        help="Use unsigned S3 access for public buckets",
+    )
+    p_ext.add_argument(
         "--stdout",
         action="store_true",
         help="Write selected variable as bytes to stdout",

--- a/src/zyra/processing/__init__.py
+++ b/src/zyra/processing/__init__.py
@@ -285,6 +285,7 @@ def register_cli(subparsers: Any) -> None:
         return 0
 
     def cmd_convert_format(args: argparse.Namespace) -> int:
+        import logging
         import os
 
         from zyra.utils.cli_helpers import configure_logging_from_env

--- a/src/zyra/processing/__init__.py
+++ b/src/zyra/processing/__init__.py
@@ -90,9 +90,6 @@ def register_cli(subparsers: Any) -> None:
     from zyra.utils.cli_helpers import (
         is_netcdf_bytes,
     )
-    from zyra.utils.cli_helpers import (
-        read_all_bytes as _read_bytes,
-    )
 
     def cmd_decode_grib2(args: argparse.Namespace) -> int:
         # Per-command verbosity/trace mapping
@@ -118,8 +115,19 @@ def register_cli(subparsers: Any) -> None:
         # fast and to avoid importing heavy modules unnecessarily, we load the
         # decoder utilities only after we've successfully read the input bytes
         # and determined that we actually need to decode.
-        data = _read_bytes(args.file_or_url)
         import logging
+
+        from zyra.utils.io_utils import read_bytes_any
+
+        try:
+            data = read_bytes_any(
+                args.file_or_url,
+                idx_pattern=getattr(args, "pattern", None),
+                unsigned=bool(getattr(args, "unsigned", False)),
+            )
+        except RuntimeError as exc:
+            logging.error(str(exc))
+            return 2
 
         if os.environ.get("ZYRA_SHELL_TRACE"):
             logging.info("+ input='%s'", args.file_or_url)
@@ -158,8 +166,22 @@ def register_cli(subparsers: Any) -> None:
             convert_to_format,
             extract_variable,
         )
+        from zyra.utils.io_utils import read_bytes_any
 
-        data = _read_bytes(args.file_or_url)
+        # The variable regex doubles as the .idx line filter for URL
+        # inputs (GRIB index lines carry the variable names), so remote
+        # sources fetch only the matching byte ranges.
+        try:
+            data = read_bytes_any(
+                args.file_or_url,
+                idx_pattern=getattr(args, "pattern", None),
+                unsigned=bool(getattr(args, "unsigned", False)),
+            )
+        except RuntimeError as exc:
+            import logging
+
+            logging.error(str(exc))
+            return 2
         if getattr(args, "stdout", False):
             out_fmt = (args.format or "netcdf").lower()
             if out_fmt not in ("netcdf", "grib2"):
@@ -292,9 +314,19 @@ def register_cli(subparsers: Any) -> None:
 
             outdir_p = Path(outdir)
             outdir_p.mkdir(parents=True, exist_ok=True)
+            from zyra.utils.io_utils import read_bytes_any
+
             wrote = []
             for src in args.inputs:
-                data = _read_bytes(src)
+                try:
+                    data = read_bytes_any(
+                        src,
+                        idx_pattern=getattr(args, "pattern", None),
+                        unsigned=bool(getattr(args, "unsigned", False)),
+                    )
+                except RuntimeError as exc:
+                    logging.error(str(exc))
+                    return 2
                 # Fast-path: NetCDF passthrough when converting to NetCDF
                 if args.format == "netcdf" and is_netcdf_bytes(data):
                     # Write source name with .nc extension
@@ -327,7 +359,17 @@ def register_cli(subparsers: Any) -> None:
 
         # Single-input flow
         # Read input first so we can short-circuit pass-through without heavy imports
-        data = _read_bytes(args.file_or_url)
+        from zyra.utils.io_utils import read_bytes_any
+
+        try:
+            data = read_bytes_any(
+                args.file_or_url,
+                idx_pattern=getattr(args, "pattern", None),
+                unsigned=bool(getattr(args, "unsigned", False)),
+            )
+        except RuntimeError as exc:
+            logging.error(str(exc))
+            return 2
         # If reading NetCDF and writing NetCDF with --stdout, pass-through
         if (
             getattr(args, "stdout", False)

--- a/src/zyra/processing/grib_utils.py
+++ b/src/zyra/processing/grib_utils.py
@@ -82,10 +82,14 @@ def grib_decode(data: bytes, backend: str = "cfgrib") -> DecodedGRIB:
             try:
                 import xarray as xr  # type: ignore
 
+                # indexpath="" disables cfgrib's index sidecar: the input
+                # is a one-shot temp file, and the previous ":auto:" value
+                # was not cfgrib magic — it became a literal pickle file
+                # named ':auto:' in the caller's working directory.
                 ds = xr.open_dataset(
                     temp_path,
                     engine="cfgrib",
-                    backend_kwargs={"indexpath": ":auto:"},
+                    backend_kwargs={"indexpath": ""},
                 )
                 return DecodedGRIB(backend="cfgrib", dataset=ds, path=temp_path)
             except ModuleNotFoundError as exc:  # pragma: no cover - optional dep

--- a/src/zyra/utils/io_utils.py
+++ b/src/zyra/utils/io_utils.py
@@ -61,3 +61,61 @@ def open_output_file(path_or_dash: str) -> BinaryIO:
     """
     # Returning an open file object is intentional for backwards compatibility.
     return sys.stdout.buffer if path_or_dash == "-" else Path(path_or_dash).open("wb")  # noqa: SIM115
+
+
+def read_bytes_any(
+    path_or_url: str,
+    *,
+    idx_pattern: str | None = None,
+    unsigned: bool = False,
+) -> bytes:
+    """Read bytes from a local path, ``-`` (stdin), or an HTTP(S)/S3 URL.
+
+    URLs support GRIB ``.idx`` sidecar subsetting: when ``idx_pattern``
+    is given, only the byte ranges whose index lines match the regex
+    are fetched (the NOAA GRIB2-on-S3 access pattern — HRRR/GFS style).
+    ``unsigned`` enables anonymous access for public S3 buckets.
+
+    Raises
+    ------
+    RuntimeError
+        On fetch failures, unsupported schemes, or missing local paths.
+        Callers map this to their own error convention (CLI handlers log
+        and return 2; ``zyra.cli`` converts to ``SystemExit``).
+    """
+    if path_or_url == "-":
+        return sys.stdin.buffer.read()
+
+    p = Path(path_or_url)
+    if p.exists():
+        return p.read_bytes()
+
+    if path_or_url.startswith(("http://", "https://")):
+        try:
+            from zyra.connectors.backends import http as http_backend
+            from zyra.utils.grib import idx_to_byteranges
+
+            if idx_pattern:
+                lines = http_backend.get_idx_lines(path_or_url)
+                ranges = idx_to_byteranges(lines, idx_pattern)
+                return http_backend.download_byteranges(path_or_url, ranges.keys())
+            return http_backend.fetch_bytes(path_or_url)
+        except Exception as exc:
+            raise RuntimeError(f"Failed to fetch from URL: {exc}") from exc
+
+    if path_or_url.startswith("s3://"):
+        try:
+            from zyra.connectors.backends import s3 as s3_backend
+            from zyra.utils.grib import idx_to_byteranges
+
+            if idx_pattern:
+                lines = s3_backend.get_idx_lines(path_or_url, unsigned=unsigned)
+                ranges = idx_to_byteranges(lines, idx_pattern)
+                return s3_backend.download_byteranges(
+                    path_or_url, None, ranges.keys(), unsigned=unsigned
+                )
+            return s3_backend.fetch_bytes(path_or_url, unsigned=unsigned)
+        except Exception as exc:
+            raise RuntimeError(f"Failed to fetch from S3: {exc}") from exc
+
+    raise RuntimeError(f"Input not found or unsupported scheme: {path_or_url}")

--- a/src/zyra/utils/io_utils.py
+++ b/src/zyra/utils/io_utils.py
@@ -88,7 +88,12 @@ def read_bytes_any(
 
     p = Path(path_or_url)
     if p.exists():
-        return p.read_bytes()
+        try:
+            return p.read_bytes()
+        except OSError as exc:
+            # Keep the advertised RuntimeError contract for unreadable
+            # paths (permissions, directories) too.
+            raise RuntimeError(f"Failed to read {path_or_url}: {exc}") from exc
 
     if path_or_url.startswith(("http://", "https://")):
         try:
@@ -98,8 +103,16 @@ def read_bytes_any(
             if idx_pattern:
                 lines = http_backend.get_idx_lines(path_or_url)
                 ranges = idx_to_byteranges(lines, idx_pattern)
+                if not ranges:
+                    # Zero matched ranges would download nothing and look
+                    # like a successful empty read.
+                    raise RuntimeError(
+                        f"No .idx lines matched pattern {idx_pattern!r} for {path_or_url}"
+                    )
                 return http_backend.download_byteranges(path_or_url, ranges.keys())
             return http_backend.fetch_bytes(path_or_url)
+        except RuntimeError:
+            raise
         except Exception as exc:
             raise RuntimeError(f"Failed to fetch from URL: {exc}") from exc
 
@@ -111,10 +124,16 @@ def read_bytes_any(
             if idx_pattern:
                 lines = s3_backend.get_idx_lines(path_or_url, unsigned=unsigned)
                 ranges = idx_to_byteranges(lines, idx_pattern)
+                if not ranges:
+                    raise RuntimeError(
+                        f"No .idx lines matched pattern {idx_pattern!r} for {path_or_url}"
+                    )
                 return s3_backend.download_byteranges(
                     path_or_url, None, ranges.keys(), unsigned=unsigned
                 )
             return s3_backend.fetch_bytes(path_or_url, unsigned=unsigned)
+        except RuntimeError:
+            raise
         except Exception as exc:
             raise RuntimeError(f"Failed to fetch from S3: {exc}") from exc
 

--- a/tests/misc/test_read_bytes_any.py
+++ b/tests/misc/test_read_bytes_any.py
@@ -124,3 +124,18 @@ def test_cli_decode_grib2_url_wiring(monkeypatch, capsysbinary):
         "pattern": "REFC",
         "unsigned": True,
     }
+
+
+def test_cli_extract_variable_accepts_unsigned():
+    # The handler threads --unsigned to read_bytes_any; the parser must
+    # actually accept the flag (parity with decode-grib2/convert-format).
+    import argparse
+
+    from zyra.processing import register_cli
+
+    parser = argparse.ArgumentParser()
+    register_cli(parser.add_subparsers(dest="cmd"))
+    ns = parser.parse_args(
+        ["extract-variable", "s3://noaa-hrrr-bdp-pds/f.grib2", "REFC", "--unsigned"]
+    )
+    assert ns.unsigned is True

--- a/tests/misc/test_read_bytes_any.py
+++ b/tests/misc/test_read_bytes_any.py
@@ -1,0 +1,106 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Shared URL-aware reader (issue: decode-grib2 URL inputs crashed).
+
+`read_bytes_any` unifies the previously duplicated logic: local paths,
+stdin, and HTTP(S)/S3 URLs with GRIB `.idx` byte-range subsetting. The
+`process` handlers and `zyra.cli` both route through it.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from zyra.utils.io_utils import read_bytes_any
+
+IDX_LINES = [
+    "1:0:d=2026072318:REFC:entire atmosphere:anl:",
+    "2:266325:d=2026072318:RETOP:cloud top:anl:",
+    "3:511819:d=2026072318:VIS:surface:anl:",
+]
+
+
+def test_local_file(tmp_path):
+    p = tmp_path / "x.bin"
+    p.write_bytes(b"GRIBdata")
+    assert read_bytes_any(str(p)) == b"GRIBdata"
+
+
+def test_missing_input_raises_runtime_error():
+    with pytest.raises(RuntimeError, match="not found or unsupported"):
+        read_bytes_any("/definitely/not/here.grib2")
+
+
+def test_http_url_plain_fetch(monkeypatch):
+    from zyra.connectors.backends import http as http_backend
+
+    monkeypatch.setattr(http_backend, "fetch_bytes", lambda url, **kw: b"FULLFILE")
+    assert read_bytes_any("https://example.org/f.grib2") == b"FULLFILE"
+
+
+def test_http_url_idx_subset(monkeypatch):
+    from zyra.connectors.backends import http as http_backend
+
+    calls = {}
+
+    def fake_idx(url, **kw):
+        calls["idx_url"] = url
+        return IDX_LINES
+
+    def fake_ranges(url, ranges, **kw):
+        calls["ranges"] = list(ranges)
+        return b"SUBSET"
+
+    monkeypatch.setattr(http_backend, "get_idx_lines", fake_idx)
+    monkeypatch.setattr(http_backend, "download_byteranges", fake_ranges)
+    out = read_bytes_any("https://example.org/f.grib2", idx_pattern="REFC")
+    assert out == b"SUBSET"
+    assert calls["idx_url"] == "https://example.org/f.grib2"
+    # Only the REFC range is requested, not the whole file.
+    assert len(calls["ranges"]) == 1
+
+
+def test_http_fetch_failure_wrapped(monkeypatch):
+    from zyra.connectors.backends import http as http_backend
+
+    def boom(url, **kw):
+        raise OSError("connection refused")
+
+    monkeypatch.setattr(http_backend, "fetch_bytes", boom)
+    with pytest.raises(RuntimeError, match="Failed to fetch from URL"):
+        read_bytes_any("https://example.org/f.grib2")
+
+
+def test_cli_decode_grib2_url_wiring(monkeypatch, capsysbinary):
+    # The registered handler must route URLs through read_bytes_any —
+    # previously it Path()-opened them and crashed.
+    import argparse
+
+    from zyra.processing import register_cli
+    from zyra.utils import io_utils
+
+    seen = {}
+
+    def fake_read(path_or_url, *, idx_pattern=None, unsigned=False):
+        seen.update(url=path_or_url, pattern=idx_pattern, unsigned=unsigned)
+        return b"GRIB-bytes"
+
+    monkeypatch.setattr(io_utils, "read_bytes_any", fake_read)
+    parser = argparse.ArgumentParser()
+    register_cli(parser.add_subparsers(dest="cmd"))
+    ns = parser.parse_args(
+        [
+            "decode-grib2",
+            "https://example.org/hrrr.grib2",
+            "--pattern",
+            "REFC",
+            "--unsigned",
+            "--raw",
+        ]
+    )
+    assert ns.func(ns) == 0
+    assert capsysbinary.readouterr().out == b"GRIB-bytes"
+    assert seen == {
+        "url": "https://example.org/hrrr.grib2",
+        "pattern": "REFC",
+        "unsigned": True,
+    }

--- a/tests/misc/test_read_bytes_any.py
+++ b/tests/misc/test_read_bytes_any.py
@@ -59,6 +59,26 @@ def test_http_url_idx_subset(monkeypatch):
     assert len(calls["ranges"]) == 1
 
 
+def test_http_idx_zero_matches_fails_loudly(monkeypatch):
+    from zyra.connectors.backends import http as http_backend
+
+    monkeypatch.setattr(http_backend, "get_idx_lines", lambda url, **kw: IDX_LINES)
+    monkeypatch.setattr(
+        http_backend,
+        "download_byteranges",
+        lambda *a, **kw: pytest.fail("should not download with zero ranges"),
+    )
+    with pytest.raises(RuntimeError, match="No .idx lines matched"):
+        read_bytes_any("https://example.org/f.grib2", idx_pattern="NOSUCHVAR")
+
+
+def test_unreadable_local_path_wrapped(tmp_path):
+    # A directory exists but cannot be read as bytes: the RuntimeError
+    # contract must hold rather than leaking OSError.
+    with pytest.raises(RuntimeError, match="Failed to read"):
+        read_bytes_any(str(tmp_path))
+
+
 def test_http_fetch_failure_wrapped(monkeypatch):
     from zyra.connectors.backends import http as http_backend
 


### PR DESCRIPTION
Implements NOAA-GSL/zyra#303 (staged downstream as #250): `process decode-grib2` advertised URL support and `.idx`-based subsetting in its own help text, but its handler read input through a file-only helper — HTTPS URLs crashed with `FileNotFoundError` while a complete, correct implementation sat unwired in `zyra.cli`.

## Changes

- The URL-aware logic moves to a single shared `io_utils.read_bytes_any` (local path, stdin, HTTP(S), S3; `.idx` sidecar parsing → byte-range subset fetch). `zyra.cli._read_bytes` now delegates to it, keeping that module's `SystemExit` convention. Raises `RuntimeError` for callers to map (handlers log + exit 2).
- `process decode-grib2`, `extract-variable`, and `convert-format` (single **and** batch) route through it, threading `--pattern`/`--unsigned` to the subset path. For `extract-variable` the variable regex doubles as the `.idx` line filter — remote sources fetch only the matching ranges.
- **cfgrib litter fix**: `indexpath=":auto:"` is not cfgrib magic — it wrote a literal pickle file named `:auto:` into the caller's working directory on every decode. The index sidecar is now disabled (`indexpath=""`) since inputs are one-shot temp files.

## Verification

- **Live acceptance run**: `zyra process decode-grib2 https://noaa-hrrr-bdp-pds.s3.amazonaws.com/hrrr.20260723/conus/hrrr.t18z.wrfsfcf00.grib2 --pattern "REFC" --raw` emits the 266,325-byte subset — byte-identical to a manual curl range fetch driven by hand-read `.idx` offsets — with no cwd litter. This command has never worked before.
- 6 new tests (`tests/misc/test_read_bytes_any.py`): local/missing/plain-URL/idx-subset/failure-wrapping via monkeypatched backends (no network in CI), plus a wiring test proving the registered `decode-grib2` handler passes URL/pattern/unsigned through and emits the bytes with `--raw`.
- `tests/processing` + `tests/misc` pass (the 2 `test_cli_smoke_streaming` failures are pre-existing, verified identical on the untouched base). `ruff` (0.6.4) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G1ZEw6d1yXepDb819YVNRP

---
_Generated by [Claude Code](https://claude.ai/code/session_01G1ZEw6d1yXepDb819YVNRP)_