### PR TITLE
Never fabricate conversion output; fix the real HRRR NetCDF failure

### DIFF
--- a/src/zyra/processing/grib_utils.py
+++ b/src/zyra/processing/grib_utils.py
@@ -303,6 +303,44 @@ def _grib_georeference(da: Any) -> tuple[Any, Any, bool] | None:
     return None
 
 
+def _netcdf_bytes(data_to_write: Any) -> bytes:
+    """Serialize an xarray object to NetCDF bytes.
+
+    Tries the in-memory writer first, normalizing the return types seen
+    in the wild (bytes, memoryview, file-like, numpy); falls back to a
+    temp file (netCDF4/h5netcdf engines write files, not buffers).
+    Raises on failure — callers decide on recovery.
+    """
+    try:
+        maybe_bytes = data_to_write.to_netcdf()
+        if isinstance(maybe_bytes, (bytes, bytearray)):
+            return bytes(maybe_bytes)
+        if isinstance(maybe_bytes, memoryview):
+            return maybe_bytes.tobytes()
+        read = getattr(maybe_bytes, "read", None)
+        if callable(read):
+            return read()
+        tobytes = getattr(maybe_bytes, "tobytes", None)
+        if callable(tobytes):
+            return tobytes()
+        raise TypeError(f"Unexpected return type from to_netcdf(): {type(maybe_bytes)}")
+    except Exception:
+        tmp = tempfile.NamedTemporaryFile(suffix=".nc", delete=False)
+        tmp_path = tmp.name
+        tmp.close()
+        try:
+            data_to_write.to_netcdf(tmp_path)
+            from pathlib import Path as _P
+
+            return _P(tmp_path).read_bytes()
+        finally:
+            import contextlib
+            from pathlib import Path as _P
+
+            with contextlib.suppress(Exception):
+                _P(tmp_path).unlink()
+
+
 def convert_to_format(
     decoded: DecodedGRIB,
     format_type: str,
@@ -380,115 +418,57 @@ def convert_to_format(
             raise ValueError("Unsupported object for DataFrame conversion")
 
         if ftype == "netcdf":
-            # Try in-memory first; fallback to temp file
+            data_to_write = obj if hasattr(obj, "to_netcdf") else ds
             try:
-                data_to_write = obj if hasattr(obj, "to_netcdf") else ds
-                maybe_bytes = data_to_write.to_netcdf()  # type: ignore
-                # Normalize various in-memory returns to raw bytes.
-                # Seen in the wild: bytes, bytearray, memoryview, BytesIO/file-like, numpy arrays.
-                if isinstance(maybe_bytes, (bytes, bytearray)):
-                    return bytes(maybe_bytes)
-                # memoryview
-                if isinstance(maybe_bytes, memoryview):
-                    return maybe_bytes.tobytes()
-                # File-like (e.g., BytesIO)
-                read = getattr(maybe_bytes, "read", None)
-                if callable(read):
-                    return read()
-                # Numpy-like objects
-                tobytes = getattr(maybe_bytes, "tobytes", None)
-                if callable(tobytes):
-                    return tobytes()
-                # If we reach here, the type is not handled.
-                raise TypeError(
-                    f"Unexpected return type from to_netcdf(): {type(maybe_bytes)}. "
-                    "Expected bytes, bytearray, memoryview, file-like object, or numpy array."
-                )
-            except Exception:
-                # Try writing to a temporary file using netCDF4 or h5netcdf engine
-                tmp = tempfile.NamedTemporaryFile(suffix=".nc", delete=False)
-                tmp_path = tmp.name
-                tmp.close()
-                try:
-                    data_to_write = obj if hasattr(obj, "to_netcdf") else ds
-                    data_to_write.to_netcdf(tmp_path)  # type: ignore
-                    from pathlib import Path as _P
-
-                    return _P(tmp_path).read_bytes()
-                except Exception as exc:
-                    # wgrib2 fallback if available: convert GRIB -> NetCDF
-                    if _has_wgrib2() and decoded.path:
-                        out_nc = tmp_path
-                        try:
-                            res = subprocess.run(
-                                ["wgrib2", decoded.path, "-netcdf", out_nc],
-                                capture_output=True,
-                                text=True,
-                                check=False,
-                            )
-                            if res.returncode != 0:
-                                # Fall back to emitting a minimal NetCDF header if conversion is not possible
-                                raise RuntimeError(
-                                    res.stderr.strip() or "wgrib2 -netcdf failed"
-                                )
-                            from pathlib import Path as _P
-
-                            return _P(out_nc).read_bytes()
-                        except Exception as e2:  # pragma: no cover - external tool
-                            # As a last resort, generate a minimal valid NetCDF file so callers can detect header
-                            try:
-                                import numpy as np  # type: ignore
-                                import xarray as xr  # type: ignore
-
-                                ds_fallback = xr.Dataset(
-                                    {"dummy": ("dummy", np.zeros(1, dtype="float32"))}
-                                )
-                                try:
-                                    maybe_bytes = ds_fallback.to_netcdf()
-                                    if isinstance(maybe_bytes, (bytes, bytearray)):
-                                        return bytes(maybe_bytes)
-                                    read = getattr(maybe_bytes, "read", None)
-                                    if callable(read):
-                                        return read()
-                                except Exception:
-                                    ds_fallback.to_netcdf(tmp_path)
-                                    from pathlib import Path as _P
-
-                                    return _P(tmp_path).read_bytes()
-                            except Exception:
-                                pass
-                            raise RuntimeError(
-                                f"NetCDF conversion failed: {e2}"
-                            ) from exc
-                    # If wgrib2 is unavailable or failed, attempt a minimal NetCDF fallback
+                return _netcdf_bytes(data_to_write)
+            except Exception as exc:
+                # Known xarray failure mode: decoding cfgrib's 'step'
+                # coordinate can assert on non-nanosecond timedeltas.
+                # Re-open without timedelta decoding and retry before
+                # reaching for wgrib2.
+                if decoded.path:
                     try:
-                        import numpy as np  # type: ignore
                         import xarray as xr  # type: ignore
 
-                        ds_fallback = xr.Dataset(
-                            {"dummy": ("dummy", np.zeros(1, dtype="float32"))}
+                        ds_raw = xr.open_dataset(
+                            decoded.path,
+                            engine="cfgrib",
+                            decode_timedelta=False,
                         )
-                        try:
-                            maybe_bytes = ds_fallback.to_netcdf()
-                            if isinstance(maybe_bytes, (bytes, bytearray)):
-                                return bytes(maybe_bytes)
-                            read = getattr(maybe_bytes, "read", None)
-                            if callable(read):
-                                return read()
-                        except Exception:
-                            ds_fallback.to_netcdf(tmp_path)
+                        obj_raw: Any = ds_raw
+                        if var:
+                            obj_raw = extract_variable(
+                                DecodedGRIB(backend="cfgrib", dataset=ds_raw), var
+                            )
+                        return _netcdf_bytes(obj_raw)
+                    except Exception:
+                        pass
+                if _has_wgrib2() and decoded.path:
+                    tmp = tempfile.NamedTemporaryFile(suffix=".nc", delete=False)
+                    tmp_path = tmp.name
+                    tmp.close()
+                    try:
+                        res = subprocess.run(
+                            ["wgrib2", decoded.path, "-netcdf", tmp_path],
+                            capture_output=True,
+                            text=True,
+                            check=False,
+                        )
+                        if res.returncode == 0:
                             from pathlib import Path as _P
 
                             return _P(tmp_path).read_bytes()
-                    except Exception:
-                        pass
-                    raise RuntimeError(f"NetCDF conversion failed: {exc}") from exc
-                finally:
-                    import contextlib
-                    from pathlib import Path as _P
+                    finally:
+                        import contextlib
+                        from pathlib import Path as _P
 
-                    with contextlib.suppress(Exception):
-                        _P(tmp_path).unlink()
+                        with contextlib.suppress(Exception):
+                            _P(tmp_path).unlink()
+                # A failed conversion is an error. Never fabricate output:
+                # a placeholder dataset returned as success poisons every
+                # downstream consumer (this previously emitted a Dataset
+                # with a single variable literally named 'dummy').
+                raise RuntimeError(f"NetCDF conversion failed: {exc}") from exc
 
         if ftype == "geotiff":
             # Enforce single-variable requirement up-front to avoid optional deps
@@ -570,29 +550,8 @@ def convert_to_format(
                 check=False,
             )
             if res.returncode != 0:
-                # Emit minimal NetCDF bytes as a last resort (header-only validation in tests)
-                try:
-                    import numpy as np  # type: ignore
-                    import xarray as xr  # type: ignore
-
-                    ds_fallback = xr.Dataset(
-                        {"dummy": ("dummy", np.zeros(1, dtype="float32"))}
-                    )
-                    maybe_bytes = ds_fallback.to_netcdf()
-                    if isinstance(maybe_bytes, (bytes, bytearray)):
-                        return bytes(maybe_bytes)
-                    read = getattr(maybe_bytes, "read", None)
-                    if callable(read):
-                        return read()
-                    # Fallback to writing file
-                    ds_fallback.to_netcdf(tmp_path)
-                    from pathlib import Path as _P
-
-                    return _P(tmp_path).read_bytes()
-                except Exception as err:
-                    raise RuntimeError(
-                        res.stderr.strip() or "wgrib2 -netcdf failed"
-                    ) from err
+                # A failed conversion is an error, never fabricated output.
+                raise RuntimeError(res.stderr.strip() or "wgrib2 -netcdf failed")
             from pathlib import Path as _P
 
             return _P(tmp_path).read_bytes()
@@ -604,30 +563,13 @@ def convert_to_format(
                 _P(tmp_path).unlink()
 
     if ftype == "geotiff":
-        # Last-resort minimal GeoTIFF to satisfy header checks when xarray path is unavailable
-        try:
-            import numpy as np  # type: ignore
-            import rasterio  # type: ignore
-
-            tmp = tempfile.NamedTemporaryFile(suffix=".tif", delete=False)
-            tmp_path = tmp.name
-            tmp.close()
-            data = np.zeros((1, 1), dtype="uint8")
-            with rasterio.open(
-                tmp_path,
-                "w",
-                driver="GTiff",
-                height=1,
-                width=1,
-                count=1,
-                dtype=data.dtype,
-            ) as dst:
-                dst.write(data, 1)
-            from pathlib import Path as _P
-
-            return _P(tmp_path).read_bytes()
-        except Exception:
-            pass
+        # No xarray dataset to rasterize. This previously fabricated a
+        # 1x1 zero GeoTIFF "to satisfy header checks" — silent fake
+        # output; a failed conversion must fail.
+        raise RuntimeError(
+            "GeoTIFF conversion requires the cfgrib backend (xarray dataset); "
+            f"decoded backend {decoded.backend!r} has no GeoTIFF path."
+        )
 
     # Non-xarray paths require explicit tooling; keep behavior clear
     raise ValueError(

--- a/src/zyra/processing/grib_utils.py
+++ b/src/zyra/processing/grib_utils.py
@@ -447,6 +447,7 @@ def convert_to_format(
                             return _netcdf_bytes(obj_raw)
                     except Exception:
                         pass
+                wgrib2_detail = ""
                 if _has_wgrib2() and decoded.path:
                     tmp = tempfile.NamedTemporaryFile(suffix=".nc", delete=False)
                     tmp_path = tmp.name
@@ -462,6 +463,13 @@ def convert_to_format(
                             from pathlib import Path as _P
 
                             return _P(tmp_path).read_bytes()
+                        # Surface the fallback's own failure detail; the
+                        # original exception alone hides what wgrib2 said.
+                        wgrib2_detail = (
+                            f"; wgrib2 fallback failed (exit {res.returncode})"
+                        )
+                        if (res.stderr or "").strip():
+                            wgrib2_detail += f": {res.stderr.strip()}"
                     finally:
                         import contextlib
                         from pathlib import Path as _P
@@ -472,7 +480,9 @@ def convert_to_format(
                 # a placeholder dataset returned as success poisons every
                 # downstream consumer (this previously emitted a Dataset
                 # with a single variable literally named 'dummy').
-                raise RuntimeError(f"NetCDF conversion failed: {exc}") from exc
+                raise RuntimeError(
+                    f"NetCDF conversion failed: {exc}{wgrib2_detail}"
+                ) from exc
 
         if ftype == "geotiff":
             # Enforce single-variable requirement up-front to avoid optional deps

--- a/src/zyra/processing/grib_utils.py
+++ b/src/zyra/processing/grib_utils.py
@@ -430,17 +430,21 @@ def convert_to_format(
                     try:
                         import xarray as xr  # type: ignore
 
-                        ds_raw = xr.open_dataset(
+                        # indexpath="" skips the .idx sidecar for the
+                        # one-shot temp file; the context manager closes
+                        # the retry dataset after serialization.
+                        with xr.open_dataset(
                             decoded.path,
                             engine="cfgrib",
+                            backend_kwargs={"indexpath": ""},
                             decode_timedelta=False,
-                        )
-                        obj_raw: Any = ds_raw
-                        if var:
-                            obj_raw = extract_variable(
-                                DecodedGRIB(backend="cfgrib", dataset=ds_raw), var
-                            )
-                        return _netcdf_bytes(obj_raw)
+                        ) as ds_raw:
+                            obj_raw: Any = ds_raw
+                            if var:
+                                obj_raw = extract_variable(
+                                    DecodedGRIB(backend="cfgrib", dataset=ds_raw), var
+                                )
+                            return _netcdf_bytes(obj_raw)
                     except Exception:
                         pass
                 if _has_wgrib2() and decoded.path:

--- a/tests/misc/test_cli_smoke_streaming.py
+++ b/tests/misc/test_cli_smoke_streaming.py
@@ -128,6 +128,8 @@ def test_grib2_to_netcdf_pipeline_header_check():
         assert (
             b"conversion failed" in res.stderr.lower() or b"error" in res.stderr.lower()
         )
+        # No partial/placeholder bytes may accompany a failure.
+        assert res.stdout == b""
 
 
 @pytest.mark.cli
@@ -172,6 +174,8 @@ def test_grib2_to_geotiff_pipeline_header_check():
     if res.returncode != 0:
         err = res.stderr.decode(errors="ignore").lower()
         assert "geotiff" in err or "conversion" in err or "error" in err
+        # No partial/placeholder bytes may accompany a failure.
+        assert res.stdout == b""
         return
     # GeoTIFF header is either little-endian "II" or big-endian "MM"
     assert res.stdout.startswith(b"II") or res.stdout.startswith(b"MM")

--- a/tests/misc/test_cli_smoke_streaming.py
+++ b/tests/misc/test_cli_smoke_streaming.py
@@ -151,8 +151,16 @@ def test_grib2_extract_variable_stdout_netcdf_header():
             "netcdf",
         ]
     )
-    assert res.returncode == 0, res.stderr.decode(errors="ignore")
-    assert res.stdout.startswith(b"CDF") or res.stdout.startswith(b"\x89HDF")
+    # Real conversion succeeds (valid NetCDF header) or fails honestly
+    # (previously a failed conversion emitted a fabricated dummy NetCDF
+    # with exit 0). demo.grib2 has no cfgrib-decodable message, so
+    # environments without wgrib2 exercise the failure branch.
+    if res.returncode == 0:
+        assert res.stdout.startswith(b"CDF") or res.stdout.startswith(b"\x89HDF")
+    else:
+        assert b"error" in res.stderr.lower() or b"unsupported" in res.stderr.lower()
+        # No partial/placeholder bytes may accompany a failure.
+        assert res.stdout == b""
 
 
 @pytest.mark.cli

--- a/tests/misc/test_cli_smoke_streaming.py
+++ b/tests/misc/test_cli_smoke_streaming.py
@@ -119,9 +119,15 @@ def test_grib2_to_netcdf_pipeline_header_check():
     res = _run_cli(
         ["process", "convert-format", "-", "netcdf", "--stdout"], input_bytes=raw
     )
-    assert res.returncode == 0, res.stderr.decode(errors="ignore")
-    # Validate NetCDF magic numbers: classic CDF or HDF5-based NetCDF4
-    assert res.stdout.startswith(b"CDF") or res.stdout.startswith(b"\x89HDF")
+    # Conversion must either succeed with real NetCDF bytes or fail with
+    # a real error — never fabricate output. (The former dummy-dataset
+    # fallback made this test pass on inputs that never converted.)
+    if res.returncode == 0:
+        assert res.stdout.startswith(b"CDF") or res.stdout.startswith(b"\x89HDF")
+    else:
+        assert (
+            b"conversion failed" in res.stderr.lower() or b"error" in res.stderr.lower()
+        )
 
 
 @pytest.mark.cli
@@ -161,6 +167,11 @@ def test_grib2_to_geotiff_pipeline_header_check():
     res = _run_cli(
         ["process", "convert-format", "-", "geotiff", "--stdout"], input_bytes=raw
     )
-    assert res.returncode == 0, res.stderr.decode(errors="ignore")
+    # Real GeoTIFF or a real error — the former 1x1 zero-GeoTIFF
+    # fabrication made this test pass without any actual conversion.
+    if res.returncode != 0:
+        err = res.stderr.decode(errors="ignore").lower()
+        assert "geotiff" in err or "conversion" in err or "error" in err
+        return
     # GeoTIFF header is either little-endian "II" or big-endian "MM"
     assert res.stdout.startswith(b"II") or res.stdout.startswith(b"MM")

--- a/tests/processing/test_convert_no_fabrication.py
+++ b/tests/processing/test_convert_no_fabrication.py
@@ -8,7 +8,6 @@ exit 0. Failures must raise so callers see the real error.
 
 from __future__ import annotations
 
-import io
 import re
 
 import pytest
@@ -42,12 +41,17 @@ def test_geotiff_without_xarray_backend_raises():
         convert_to_format(decoded, "geotiff")
 
 
-def test_netcdf_bytes_roundtrip_real_dataset():
+def test_netcdf_bytes_roundtrip_real_dataset(tmp_path):
     ds = xr.Dataset({"t": (("y", "x"), np.arange(6, dtype="float32").reshape(2, 3))})
     out = _netcdf_bytes(ds)
     assert out[:3] == b"CDF" or out[:4] == b"\x89HDF"
-    back = xr.open_dataset(io.BytesIO(out))
-    assert "t" in back and float(back["t"].values[1, 2]) == 5.0
+    # Re-open via a real file: file-like reads only work with some
+    # engines (e.g. scipy/h5netcdf), while a path works with any
+    # installed NetCDF engine — mirrors load_netcdf's approach.
+    p = tmp_path / "roundtrip.nc"
+    p.write_bytes(out)
+    with xr.open_dataset(p) as back:
+        assert "t" in back and float(back["t"].values[1, 2]) == 5.0
 
 
 def test_no_dummy_variable_can_escape():

--- a/tests/processing/test_convert_no_fabrication.py
+++ b/tests/processing/test_convert_no_fabrication.py
@@ -1,0 +1,59 @@
+# SPDX-License-Identifier: Apache-2.0
+"""convert-format must never fabricate output (issue: dummy dataset).
+
+A failed conversion previously returned a placeholder — a NetCDF with
+one variable literally named 'dummy', or a 1x1 zero GeoTIFF — with
+exit 0. Failures must raise so callers see the real error.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+xr = pytest.importorskip("xarray")
+np = pytest.importorskip("numpy")
+
+from zyra.processing.grib_utils import (  # noqa: E402
+    DecodedGRIB,
+    _netcdf_bytes,
+    convert_to_format,
+)
+
+
+class _Unwritable:
+    """Quacks like a Dataset but always fails to serialize."""
+
+    def to_netcdf(self, *a, **k):
+        raise OSError("disk on fire")
+
+
+def test_failed_netcdf_conversion_raises_not_fabricates():
+    decoded = DecodedGRIB(backend="cfgrib", dataset=_Unwritable(), path=None)
+    with pytest.raises(RuntimeError, match="NetCDF conversion failed"):
+        convert_to_format(decoded, "netcdf")
+
+
+def test_geotiff_without_xarray_backend_raises():
+    decoded = DecodedGRIB(backend="pygrib", messages=[], path=None)
+    with pytest.raises(RuntimeError, match="no GeoTIFF path"):
+        convert_to_format(decoded, "geotiff")
+
+
+def test_netcdf_bytes_roundtrip_real_dataset():
+    ds = xr.Dataset({"t": (("y", "x"), np.arange(6, dtype="float32").reshape(2, 3))})
+    out = _netcdf_bytes(ds)
+    assert out[:3] == b"CDF" or out[:4] == b"\x89HDF"
+    back = xr.open_dataset(__import__("io").BytesIO(out))
+    assert "t" in back and float(back["t"].values[1, 2]) == 5.0
+
+
+def test_no_dummy_variable_can_escape():
+    # Regression guard: the string 'dummy' appears nowhere as a dataset
+    # variable in any conversion output path (source-level assertion).
+    import inspect
+
+    import zyra.processing.grib_utils as gu
+
+    src = inspect.getsource(gu)
+    assert 'xr.Dataset(\n            {"dummy"' not in src
+    assert '{"dummy": ("dummy"' not in src

--- a/tests/processing/test_convert_no_fabrication.py
+++ b/tests/processing/test_convert_no_fabrication.py
@@ -8,6 +8,9 @@ exit 0. Failures must raise so callers see the real error.
 
 from __future__ import annotations
 
+import io
+import re
+
 import pytest
 
 xr = pytest.importorskip("xarray")
@@ -43,17 +46,17 @@ def test_netcdf_bytes_roundtrip_real_dataset():
     ds = xr.Dataset({"t": (("y", "x"), np.arange(6, dtype="float32").reshape(2, 3))})
     out = _netcdf_bytes(ds)
     assert out[:3] == b"CDF" or out[:4] == b"\x89HDF"
-    back = xr.open_dataset(__import__("io").BytesIO(out))
+    back = xr.open_dataset(io.BytesIO(out))
     assert "t" in back and float(back["t"].values[1, 2]) == 5.0
 
 
 def test_no_dummy_variable_can_escape():
-    # Regression guard: the string 'dummy' appears nowhere as a dataset
-    # variable in any conversion output path (source-level assertion).
+    # Regression guard: no fabricated 'dummy' dataset construction may
+    # reappear in any conversion path. Regex-based so it survives
+    # formatting changes.
     import inspect
 
     import zyra.processing.grib_utils as gu
 
     src = inspect.getsource(gu)
-    assert 'xr.Dataset(\n            {"dummy"' not in src
-    assert '{"dummy": ("dummy"' not in src
+    assert not re.search(r"Dataset\(\s*\{\s*[\"']dummy[\"']", src)


### PR DESCRIPTION
Implements NOAA-GSL/zyra#301 (staged downstream as #248): `convert_to_format` had **three** fallback branches that turned a failed conversion into fake success — two returned a NetCDF whose only variable is literally named `dummy`, and one returned a **1×1 zero GeoTIFF** "to satisfy header checks". Exit 0, file written, downstream poisoned.

## Changes

- All three fabrication sites removed. A failed conversion raises `RuntimeError` carrying the underlying error. The legitimate recovery chain (in-memory → temp file → wgrib2) is preserved and de-duplicated into a `_netcdf_bytes` helper.
- **Root cause found and fixed** (part 2 of the issue): with errors no longer swallowed, the actual HRRR failure surfaced — xarray's timedelta decoding **asserts** on cfgrib's `step` coordinate (non-nanosecond resolution, an xarray/pandas interaction). The netcdf path now retries by re-opening the decoded GRIB with `decode_timedelta=False` before falling back to wgrib2.
- The two streaming header-check tests were validating **fabricated output on inputs that never actually converted** — they now accept real success (valid magic bytes) or a real error, never fake output.

## Verification

- **Live**: the exact HRRR REFC message that produced a 124-byte `dummy` stub now converts to real NetCDF — `refc` 1059×1799, max 67.1 dBZ, full coordinate set.
- The previously-failing `test_grib2_to_netcdf_pipeline_header_check` **now passes with real output** in this environment — the fabrication was masking a fixable bug the whole time.
- New tests: failed conversions raise (never fabricate), `_netcdf_bytes` round-trips a real dataset, geotiff without an xarray backend raises, and a source-level regression guard keeps the dummy pattern from returning.
- `tests/processing` 51 passed; the one remaining streaming failure (`extract-variable`) is pre-existing on the untouched base. `ruff` (0.6.4) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G1ZEw6d1yXepDb819YVNRP

---
_Generated by [Claude Code](https://claude.ai/code/session_01G1ZEw6d1yXepDb819YVNRP)_