### PR TITLE
Do not set PROJ_LIB unconditionally in the zyra image

### DIFF
--- a/docker/zyra/Dockerfile
+++ b/docker/zyra/Dockerfile
@@ -62,9 +62,18 @@ RUN apt-get update \
        fi \
     && rm -rf /var/lib/apt/lists/*
 
-# Help Python GDAL find the system gdal-config when building wheels if needed
+# Help Python GDAL find the system gdal-config when building wheels if needed.
+#
+# PROJ_LIB is deliberately NOT set here. /usr/share/proj only exists on
+# arm64, where the block above apt-installs proj-data; on amd64 the
+# geospatial stack comes from manylinux wheels that bundle their own
+# PROJ data, and an explicit PROJ_LIB pointing at a missing directory
+# overrides rasterio's in-wheel lookup, breaking every CRS operation
+# with "Cannot find proj.db". Leaving it unset lets rasterio/pyproj
+# resolve their bundled data on amd64 and lets the system libproj use
+# its compiled-in default path on arm64 -- the same reason GDAL_DATA is
+# not set here either.
 ENV GDAL_CONFIG=/usr/bin/gdal-config \
-    PROJ_LIB=/usr/share/proj \
     ECCODES_DIR=/usr
 
 # Optionally install source-built wgrib2 without copying when not needed


### PR DESCRIPTION
Closes #263 (upstream NOAA-GSL/zyra#318).

## Problem

`docker/zyra/Dockerfile` sets:

```dockerfile
ENV GDAL_CONFIG=/usr/bin/gdal-config \
    PROJ_LIB=/usr/share/proj \
    ECCODES_DIR=/usr
```

`/usr/share/proj` only exists on **arm64**, where the arch-conditional block above apt-installs `proj-data`. On amd64 the geospatial stack comes from manylinux wheels that bundle their own PROJ data, so `PROJ_LIB` points at a directory that does not exist. rasterio only fills in `PROJ_LIB`/`PROJ_DATA` when they are unset, so the bad explicit value wins and every CRS operation fails:

```
ERROR 1: PROJ: internal_proj_create_from_database: Cannot find proj.db
Stage 2 [process] failed with exit code 2.
Command: zyra process convert-format - geotiff --output /work/output/smoke.tif
```

This breaks `convert-format geotiff` (the `_grib_georeference` path from #307), `process reproject`, and anything else that builds a CRS — in the published `ghcr.io/noaa-gsl/zyra:v0.1.49` image. Found on the first live container run of a real GEFS-Aerosols workflow; the identical pipeline succeeds outside the container, where `PROJ_LIB` is unset.

## Fix

Drop `PROJ_LIB` from the `ENV` line, with a comment recording why it must stay unset. This matches how `GDAL_DATA` is already handled — and that contrast is exactly what pinned the diagnosis, since GDAL data resolved correctly from the package in the same failing run (`GDAL data found in package: path='.../rasterio/gdal_data'`).

Unset is correct on both arches:

- **amd64**: rasterio/pyproj resolve their bundled data (`site-packages/rasterio/proj_data/proj.db`, verified present in the wheel).
- **arm64**: the apt-installed libproj uses its compiled-in default search path, which is `/usr/share/proj` — the very directory `proj-data` populates.

`docker/zyra-scheduler/Dockerfile` does not set `PROJ_LIB`, so it needs no change.

## Verification

The real check is a rebuilt amd64 image:

```
python -c "from rasterio.crs import CRS; print(CRS.from_epsg(4326))"
zyra process convert-format <grib> geotiff --output out.tif
```

Both currently fail in v0.1.49 and should succeed after this. TerraViz carries a defensive runner-side guard in the meantime (zyra-project/terraviz#315) that clears `PROJ_LIB` only when it lacks a `proj.db`, so it becomes a no-op once this ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G1ZEw6d1yXepDb819YVNRP

---
_Generated by [Claude Code](https://claude.ai/code/session_01G1ZEw6d1yXepDb819YVNRP)_