### PR TITLE
Make visualize heatmap batch mode reachable (--input not required)

### DIFF
--- a/src/zyra/visualization/cli_heatmap.py
+++ b/src/zyra/visualization/cli_heatmap.py
@@ -39,6 +39,10 @@ def _handle_heatmap_impl(ns) -> int:
 
     ns.extent = resolve_extent(ns)
     cmap, norm = resolve_cmap_args(ns)
+    if not getattr(ns, "inputs", None) and not getattr(ns, "input", None):
+        raise ValueError(
+            "--input is required (or use --inputs with --output-dir for batch rendering)"
+        )
     # Batch mode: --inputs with --output-dir
     if getattr(ns, "inputs", None):
         outdir = getattr(ns, "output_dir", None)

--- a/src/zyra/visualization/cli_register.py
+++ b/src/zyra/visualization/cli_register.py
@@ -26,8 +26,9 @@ def register_cli(subparsers: Any) -> None:
     p_hm = subparsers.add_parser("heatmap", help="Visualization: render 2D heatmap")
     # Not required=True: batch rendering supplies --inputs/--output-dir
     # instead, and an argparse-level requirement made that documented
-    # mode unreachable. The handler validates that exactly one form is
-    # present (contour already declares --input the same way).
+    # mode unreachable. The handler requires at least one of the two
+    # forms; when both are given, --inputs wins and --input is ignored.
+    # (contour already declares --input the same way.)
     p_hm.add_argument("--input", help="Path to .nc/.nc4, .npy, or .tif/.tiff input")
     p_hm.add_argument("--var", help="Variable name for NetCDF inputs")
     p_hm.add_argument(

--- a/src/zyra/visualization/cli_register.py
+++ b/src/zyra/visualization/cli_register.py
@@ -24,9 +24,11 @@ def register_cli(subparsers: Any) -> None:
 
     # heatmap
     p_hm = subparsers.add_parser("heatmap", help="Visualization: render 2D heatmap")
-    p_hm.add_argument(
-        "--input", required=True, help="Path to .nc/.nc4, .npy, or .tif/.tiff input"
-    )
+    # Not required=True: batch rendering supplies --inputs/--output-dir
+    # instead, and an argparse-level requirement made that documented
+    # mode unreachable. The handler validates that exactly one form is
+    # present (contour already declares --input the same way).
+    p_hm.add_argument("--input", help="Path to .nc/.nc4, .npy, or .tif/.tiff input")
     p_hm.add_argument("--var", help="Variable name for NetCDF inputs")
     p_hm.add_argument(
         "--band",

--- a/src/zyra/wizard/zyra_capabilities.json
+++ b/src/zyra/wizard/zyra_capabilities.json
@@ -3166,8 +3166,7 @@
       "--input": {
         "help": "Path to .nc/.nc4, .npy, or .tif/.tiff input",
         "path_arg": true,
-        "type": "path",
-        "required": true
+        "type": "path"
       },
       "--var": "Variable name for NetCDF inputs",
       "--band": {
@@ -4547,13 +4546,7 @@
       "--basemap": "Optional basemap (path, bare image name, or pkg:ref) drawn under the data",
       "--extent": {
         "help": "west east south north (default: global -180 180 -90 90)",
-        "type": "float",
-        "default": [
-          -180,
-          180,
-          -90,
-          90
-        ]
+        "type": "float"
       },
       "--width": {
         "help": "Output width (px)",
@@ -4667,8 +4660,7 @@
       "--input": {
         "help": "Path to .nc/.nc4, .npy, or .tif/.tiff input",
         "path_arg": true,
-        "type": "path",
-        "required": true
+        "type": "path"
       },
       "--var": "Variable name for NetCDF inputs",
       "--band": {
@@ -5877,13 +5869,7 @@
       "--basemap": "Optional basemap (path, bare image name, or pkg:ref) drawn under the data",
       "--extent": {
         "help": "west east south north (default: global -180 180 -90 90)",
-        "type": "float",
-        "default": [
-          -180,
-          180,
-          -90,
-          90
-        ]
+        "type": "float"
       },
       "--width": {
         "help": "Output width (px)",

--- a/src/zyra/wizard/zyra_capabilities/visualize.json
+++ b/src/zyra/wizard/zyra_capabilities/visualize.json
@@ -605,8 +605,7 @@
       "--input": {
         "help": "Path to .nc/.nc4, .npy, or .tif/.tiff input",
         "path_arg": true,
-        "type": "path",
-        "required": true
+        "type": "path"
       },
       "--var": "Variable name for NetCDF inputs",
       "--band": {
@@ -987,13 +986,7 @@
       "--basemap": "Optional basemap (path, bare image name, or pkg:ref) drawn under the data",
       "--extent": {
         "help": "west east south north (default: global -180 180 -90 90)",
-        "type": "float",
-        "default": [
-          -180,
-          180,
-          -90,
-          90
-        ]
+        "type": "float"
       },
       "--width": {
         "help": "Output width (px)",
@@ -1986,8 +1979,7 @@
       "--input": {
         "help": "Path to .nc/.nc4, .npy, or .tif/.tiff input",
         "path_arg": true,
-        "type": "path",
-        "required": true
+        "type": "path"
       },
       "--var": "Variable name for NetCDF inputs",
       "--band": {
@@ -2444,13 +2436,7 @@
       "--basemap": "Optional basemap (path, bare image name, or pkg:ref) drawn under the data",
       "--extent": {
         "help": "west east south north (default: global -180 180 -90 90)",
-        "type": "float",
-        "default": [
-          -180,
-          180,
-          -90,
-          90
-        ]
+        "type": "float"
       },
       "--width": {
         "help": "Output width (px)",

--- a/tests/visualization/test_geotiff_input.py
+++ b/tests/visualization/test_geotiff_input.py
@@ -271,7 +271,7 @@ def test_heatmap_batch_does_not_require_single_input():
     assert ns.input is None
 
 
-def test_heatmap_without_any_input_exits_2(tmp_path):
+def test_heatmap_without_any_input_exits_2():
     # Dropping required=True must still reject "neither form given",
     # with a clear message rather than a traceback.
     import subprocess

--- a/tests/visualization/test_geotiff_input.py
+++ b/tests/visualization/test_geotiff_input.py
@@ -253,3 +253,36 @@ def test_render_band_zero_surfaces_range_error(tmp_path):
     _write_tif(tif, np.zeros((2, 2), dtype="float32"))
     with pytest.raises(ValueError, match="out of range"):
         HeatmapManager(extent=[-180, 180, -90, 90]).render(input_path=tif, band=0)
+
+
+def test_heatmap_batch_does_not_require_single_input():
+    # --inputs/--output-dir is a documented batch mode; an argparse-level
+    # required=True on --input made it unreachable (contour never had it).
+    import argparse
+
+    import zyra.visualization as vpkg
+
+    parser = argparse.ArgumentParser()
+    vpkg.register_cli(parser.add_subparsers(dest="cmd"))
+    ns = parser.parse_args(
+        ["heatmap", "--inputs", "a.tif", "b.tif", "--output-dir", "out"]
+    )
+    assert ns.inputs == ["a.tif", "b.tif"]
+    assert ns.input is None
+
+
+def test_heatmap_without_any_input_exits_2(tmp_path):
+    # Dropping required=True must still reject "neither form given",
+    # with a clear message rather than a traceback.
+    import subprocess
+    import sys
+
+    proc = subprocess.run(
+        [sys.executable, "-m", "zyra.cli", "visualize", "heatmap", "--output", "o.png"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert proc.returncode == 2
+    assert "--input is required" in proc.stderr
+    assert "Traceback" not in proc.stderr


### PR DESCRIPTION
## Problem

`visualize heatmap` advertises batch rendering (`--inputs` + `--output-dir`, and `handle_heatmap` branches on `inputs` before touching `input`), but the parser declared:

```python
p_hm.add_argument("--input", required=True, help=...)
```

so argparse rejected every batch invocation before the handler ever ran:

```
zyra visualize heatmap: error: the following arguments are required: --input
```

The documented mode was unreachable. `contour` declares the same flag without `required=True`, so its identical batch mode has always worked — this just brings heatmap in line.

Hit in production: a scheduled TerraViz workflow rendering a five-frame animation, where collapsing five render stages into one batch stage is the difference between fitting the 12-stage pipeline budget and blowing it.

## Fix

- Drop `required=True` from heatmap's `--input`, with a comment recording why (so it does not get "helpfully" restored).
- Validate in the handler instead: neither `--input` nor `--inputs` now raises `ValueError("--input is required (or use --inputs with --output-dir for batch rendering)")`, which the existing wrapper turns into a clean exit 2 — same contract as the other input errors, no traceback.

## Testing

- New parser test: `--inputs a.tif b.tif --output-dir out` parses, with `ns.input is None`.
- New subprocess test: neither form given exits 2 with the clear message and no traceback.
- Existing suite green (12 passed / 2 env-skipped in the file); capabilities manifests and the OpenAPI snapshot regenerated; ruff clean.
- Verified by hand that the batch path renders correctly once the parser allows it (two GeoTIFF inputs → two PNGs + the usual `{"outputs": [...]}` summary).

## Note

Until this ships in a release, the workaround is to pass `--input` *and* `--inputs` together — the handler ignores the former in batch mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G1ZEw6d1yXepDb819YVNRP

---
_Generated by [Claude Code](https://claude.ai/code/session_01G1ZEw6d1yXepDb819YVNRP)_