### PR TITLE
Install the DCO commit-msg hook on session start

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# SessionStart hook: install the repo's git hooks in a fresh checkout.
+#
+# .pre-commit-config.yaml already declares `require-dco-signoff`, but a
+# remote session clones the repo fresh into a container where nothing
+# has run `pre-commit install`, so .git/hooks/ is empty and the check
+# never fires. Commits then reach the PR before the DCO app rejects
+# them, which costs a force-push and invalidates review anchors.
+#
+# This installs the commit-msg hook directly rather than shelling out
+# to `pre-commit`: check_dco_signoff.sh is a dependency-free bash
+# script, so wiring it needs neither pre-commit nor a working Poetry
+# environment. The other hooks in .pre-commit-config.yaml DO call
+# `poetry run`, which is why they are deliberately not installed here
+# (see docs note in CLAUDE.md).
+set -euo pipefail
+
+ROOT="${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
+CHECK="$ROOT/scripts/check_dco_signoff.sh"
+HOOK_DIR="$(git -C "$ROOT" rev-parse --git-path hooks 2>/dev/null || echo "$ROOT/.git/hooks")"
+HOOK="$HOOK_DIR/commit-msg"
+MARKER="zyra-dco-signoff-hook"
+
+if [[ ! -f "$CHECK" ]]; then
+  echo "session-start: $CHECK not found; skipping git hook install" >&2
+  exit 0
+fi
+
+# Never clobber a hook this script did not write (a developer's own
+# commit-msg hook, or pre-commit's, both of which already do the job).
+if [[ -e "$HOOK" ]] && ! grep -q "$MARKER" "$HOOK" 2>/dev/null; then
+  echo "session-start: $HOOK already exists and is not ours; leaving it alone" >&2
+  exit 0
+fi
+
+mkdir -p "$HOOK_DIR"
+cat > "$HOOK" <<HOOK_EOF
+#!/usr/bin/env bash
+# $MARKER — installed by .claude/hooks/session-start.sh
+exec "\$(git rev-parse --show-toplevel)/scripts/check_dco_signoff.sh" "\$@"
+HOOK_EOF
+chmod +x "$HOOK"
+echo "session-start: installed DCO commit-msg hook at $HOOK"

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -14,12 +14,20 @@
 # script, so wiring it needs neither pre-commit nor a working Poetry
 # environment. The other hooks in .pre-commit-config.yaml DO call
 # `poetry run`, which is why they are deliberately not installed here
-# (see docs note in CLAUDE.md).
+# (see the note in AGENTS.md).
 set -euo pipefail
 
 ROOT="${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
 CHECK="$ROOT/scripts/check_dco_signoff.sh"
-HOOK_DIR="$(git -C "$ROOT" rev-parse --git-path hooks 2>/dev/null || echo "$ROOT/.git/hooks")"
+HOOK_DIR="$(git -C "$ROOT" rev-parse --git-path hooks 2>/dev/null || echo ".git/hooks")"
+# `--git-path` reports relative to the repo root even under `-C`, so a
+# session started anywhere but the root would otherwise test and write
+# through a path resolved against the wrong directory. `--path-format`
+# would do this, but it needs git 2.31; this does not.
+case "$HOOK_DIR" in
+  /*) ;;
+  *) HOOK_DIR="$ROOT/$HOOK_DIR" ;;
+esac
 HOOK="$HOOK_DIR/commit-msg"
 MARKER="zyra-dco-signoff-hook"
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,13 @@ Pre-commit Hooks
 - Run hooks manually on all files: `poetry run pre-commit run -a`
 - Hooks enforce Ruff formatting/linting (authoritative list in the config above).
 - DCO: All commits must include a Signed-off-by line (see CONTRIBUTING). Add `-s` to `git commit` or enable global sign-off: `git config --global format.signoff true`.
+- Hosted/ephemeral sessions (Claude Code on the web and similar) clone the
+  repo fresh into a container where the one-time setup above has not run, so
+  `.git/hooks/` is empty and none of these hooks fire. `.claude/hooks/session-start.sh`
+  installs the DCO `commit-msg` hook on session start so unsigned commits fail
+  locally instead of at the PR. It installs only that hook — the rest shell out
+  to `poetry run`, which needs a provisioned Poetry environment the container
+  may not have.
 
 Agent Checklist (before returning code)
 


### PR DESCRIPTION
## Problem

Three of my PRs failed the DCO check tonight, and fixing them cost a history rewrite that invalidated in-flight review anchors on two of them.

Neither existing safeguard helps in a hosted session:

- `.pre-commit-config.yaml` **already** declares `require-dco-signoff` at the `commit-msg` stage — correctly.
- `AGENTS.md` **already** says "All commits must include a Signed-off-by line… Add `-s` to `git commit`."

But a hosted session (Claude Code on the web and similar) clones the repo fresh into a container where the one-time `poetry run pre-commit install` has never run. `.git/hooks/` is empty, so the check is dead code. An unsigned commit then travels all the way to the PR before the GitHub DCO app rejects it — the most expensive place to catch it.

The rule was documented and the checker was written. Only the wiring was missing.

## Change

A `SessionStart` hook that installs the `commit-msg` hook directly, so the failure lands at `git commit` instead of at the PR.

**Installed by hand rather than via `pre-commit install`, deliberately.** `scripts/check_dco_signoff.sh` is a dependency-free bash script, so wiring it needs neither `pre-commit` nor a provisioned Poetry environment. The other three hooks in the config shell out to `poetry run`, and in a container without a provisioned env that fails:

```
$ poetry run python -c "import zyra"
ModuleNotFoundError: No module named 'zyra'
```

Installing those would break *every* commit rather than just the unsigned ones. `AGENTS.md` records the split so the omission reads as a decision rather than an oversight.

The installer is idempotent, and refuses to overwrite a `commit-msg` hook it did not write — a developer's own hook, or one `pre-commit install` placed, survives untouched (matched on a marker comment).

## Validation

| check | result |
|---|---|
| Hook runs clean, installs `.git/hooks/commit-msg` executable | ✅ |
| Idempotent (second run) | ✅ |
| Refuses to clobber a foreign `commit-msg` hook | ✅ leaves it, logs why |
| **Unsigned commit rejected** | ✅ exit 1, DCO error, `HEAD` unmoved |
| **Signed commit (`-s`) accepted** | ✅ exit 0, trailer present |
| `bash -n` on the hook; `settings.json` parses | ✅ |
| Linter on a sample file (`ruff check`) | ✅ |
| A test (`test_round_trip_polar_stereo_marker`) | ✅ 1 passed |

The end-to-end pair is the one that matters:

```
$ git commit -m "unsigned"
exit=1
ERROR: Commit message missing 'Signed-off-by: Name <email>' line (DCO).
HEAD still: baaedc1b ci: bump version

$ git commit -s -m "signed"
exit=0
signoff: Claude <noreply@anthropic.com>
```

This commit is itself signed off by the installed hook.

## Note on execution mode

The hook runs **synchronously**. It is a sub-second file write with no network or package install, so async would trade a guarantee for nothing. Session startup is unaffected in any measurable way.

## Scope

Does not attempt to fix the underlying Poetry gap — that also disables `zyra-generate-manifest`, `zyra-update-openapi-snapshots`, and `spdx-headers` in hosted containers, which is why those regenerations have been manual. That belongs in environment provisioning, not a git hook, and is worth its own issue.

Once this merges to the default branch, every future session picks it up automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G1ZEw6d1yXepDb819YVNRP

---
_Generated by [Claude Code](https://claude.ai/code/session_01G1ZEw6d1yXepDb819YVNRP)_