### PR TITLE
Give animate, vector, and sos the same exit-code contract

### DIFF
--- a/src/zyra/visualization/cli_animate.py
+++ b/src/zyra/visualization/cli_animate.py
@@ -11,7 +11,22 @@ from zyra.visualization.cli_utils import features_from_ns, resolve_basemap_ref
 
 
 def handle_animate(ns) -> int:
-    """Handle ``visualize animate`` CLI subcommand."""
+    """Handle ``visualize animate`` CLI subcommand.
+
+    Argument errors surface as a clean logged error with exit code 2
+    instead of a traceback or a bare exit 1 — the same contract
+    ``handle_heatmap``/``handle_contour`` use. Runtime failures
+    (render/ffmpeg errors) and the ``--to-video`` path guards keep
+    raising ``SystemExit`` deliberately.
+    """
+    try:
+        return _handle_animate_impl(ns)
+    except ValueError as exc:
+        logging.error(str(exc))
+        return 2
+
+
+def _handle_animate_impl(ns) -> int:
     if getattr(ns, "verbose", False):
         os.environ["ZYRA_VERBOSITY"] = "debug"
     elif getattr(ns, "quiet", False):
@@ -25,7 +40,7 @@ def handle_animate(ns) -> int:
     # Batch mode for animate: --inputs with --output-dir
     if getattr(ns, "inputs", None):
         if not ns.output_dir:
-            raise SystemExit("--output-dir is required when using --inputs")
+            raise ValueError("--output-dir is required when using --inputs")
         from zyra.processing.video_processor import VideoProcessor
         from zyra.visualization.animate_manager import AnimateManager
 

--- a/src/zyra/visualization/cli_sos.py
+++ b/src/zyra/visualization/cli_sos.py
@@ -78,7 +78,21 @@ def handle_sos(ns) -> int:
     Renders one or more gridded inputs as Science On a Sphere frames using
     :class:`PlotManager`, with a fixed ``--vmin``/``--vmax`` color range for
     flicker-free frame sequences.
+
+    Argument errors surface as a clean logged error with exit code 2
+    instead of a bare exit 1 — the same contract
+    ``handle_heatmap``/``handle_contour`` use. Render failures keep
+    raising ``SystemExit`` deliberately, so a pipeline never treats an
+    empty or failed render as success.
     """
+    try:
+        return _handle_sos_impl(ns)
+    except ValueError as exc:
+        logging.error(str(exc))
+        return 2
+
+
+def _handle_sos_impl(ns) -> int:
     if getattr(ns, "verbose", False):
         os.environ["ZYRA_VERBOSITY"] = "debug"
     elif getattr(ns, "quiet", False):
@@ -96,7 +110,7 @@ def handle_sos(ns) -> int:
     if getattr(ns, "inputs", None):
         outdir = getattr(ns, "output_dir", None)
         if not outdir:
-            raise SystemExit("--output-dir is required when using --inputs")
+            raise ValueError("--output-dir is required when using --inputs")
         outdir_p = Path(outdir)
         outdir_p.mkdir(parents=True, exist_ok=True)
         outputs: list[str] = []
@@ -123,9 +137,9 @@ def handle_sos(ns) -> int:
 
     # Single input mode
     if not getattr(ns, "input", None):
-        raise SystemExit("--input or --inputs is required")
+        raise ValueError("--input or --inputs is required")
     if not getattr(ns, "output", None):
-        raise SystemExit("--output is required when using --input")
+        raise ValueError("--output is required when using --input")
     out = _render_one(ns, ns.input, ns.output)
     if not out:
         raise SystemExit(f"Failed to render SOS frame from {ns.input}")

--- a/src/zyra/visualization/cli_vector.py
+++ b/src/zyra/visualization/cli_vector.py
@@ -11,7 +11,22 @@ from zyra.visualization.cli_utils import features_from_ns, resolve_basemap_ref
 
 
 def handle_vector(ns) -> int:
-    """Handle ``visualize vector`` CLI subcommand."""
+    """Handle ``visualize vector`` CLI subcommand.
+
+    Argument errors surface as a clean logged error with exit code 2
+    instead of a traceback or a bare exit 1 — the same contract
+    ``handle_heatmap``/``handle_contour`` use. Runtime failures
+    (render/ffmpeg errors) and the ``--to-video`` path guards keep
+    raising ``SystemExit`` deliberately.
+    """
+    try:
+        return _handle_vector_impl(ns)
+    except ValueError as exc:
+        logging.error(str(exc))
+        return 2
+
+
+def _handle_vector_impl(ns) -> int:
     # Lazy import to reduce startup cost when visualization isn't used
     from zyra.visualization.vector_field_manager import VectorFieldManager
 
@@ -29,7 +44,7 @@ def handle_vector(ns) -> int:
     if getattr(ns, "inputs", None):
         outdir = getattr(ns, "output_dir", None)
         if not outdir:
-            raise SystemExit("--output-dir is required when using --inputs")
+            raise ValueError("--output-dir is required when using --inputs")
         outdir_p = Path(outdir)
         outdir_p.mkdir(parents=True, exist_ok=True)
         features = features_from_ns(ns)

--- a/src/zyra/visualization/cli_vector.py
+++ b/src/zyra/visualization/cli_vector.py
@@ -14,10 +14,10 @@ def handle_vector(ns) -> int:
     """Handle ``visualize vector`` CLI subcommand.
 
     Argument errors surface as a clean logged error with exit code 2
-    instead of a traceback or a bare exit 1 — the same contract
-    ``handle_heatmap``/``handle_contour`` use. Runtime failures
-    (render/ffmpeg errors) and the ``--to-video`` path guards keep
-    raising ``SystemExit`` deliberately.
+    instead of a bare exit 1 — the same contract
+    ``handle_heatmap``/``handle_contour`` use. This handler raises no
+    ``SystemExit`` of its own; ``animate`` and ``sos`` do, for path
+    guards and render failures respectively.
     """
     try:
         return _handle_vector_impl(ns)

--- a/tests/cli/test_batch_inputs_extend.py
+++ b/tests/cli/test_batch_inputs_extend.py
@@ -184,3 +184,104 @@ def test_contour_schema_rejects_empty_inputs():
     # Both valid forms still validate.
     assert VisualizeContourArgs(inputs=["a.tif"], output_dir="out").output is None
     assert VisualizeContourArgs(output="o.png").output == "o.png"
+
+
+# ---- Exit-code contract across the remaining batch handlers ---------------
+# heatmap and contour got the ValueError -> logged exit 2 wrapper first;
+# animate, vector, and sos still raised SystemExit with a string, which
+# exits 1 and skips the logged-error path. Only ARGUMENT errors move:
+# runtime failures and the --to-video path guards stay SystemExit.
+
+
+def _run_visualize(cmd, extra):
+    import subprocess
+    import sys
+
+    return subprocess.run(
+        [sys.executable, "-m", "zyra.cli", "visualize", cmd, *extra],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+@pytest.mark.parametrize("cmd", ["animate", "vector", "sos"])
+def test_batch_missing_output_dir_exits_2_for_remaining_handlers(cmd):
+    proc = _run_visualize(cmd, ["--inputs", "a.nc", "b.nc"])
+    assert proc.returncode == 2, f"{cmd}: rc={proc.returncode}\n{proc.stderr}"
+    assert "--output-dir is required" in proc.stderr
+    assert "Traceback" not in proc.stderr
+
+
+def test_sos_single_mode_argument_errors_exit_2():
+    proc = _run_visualize("sos", [])
+    assert proc.returncode == 2, proc.stderr
+    assert "--input or --inputs is required" in proc.stderr
+    assert "Traceback" not in proc.stderr
+
+    proc = _run_visualize("sos", ["--input", "x.nc"])
+    assert proc.returncode == 2, proc.stderr
+    assert "--output is required" in proc.stderr
+    assert "Traceback" not in proc.stderr
+
+
+def _raise_kinds(module):
+    """Map each raised message fragment to the SET of exception classes
+    raised with it.
+
+    Parsed from the AST rather than matched against source text: a
+    substring search picks up a neighbouring raise and passes even when
+    the statement it names has changed type. A set rather than a single
+    value because some messages are raised from more than one code path
+    (``--to-video`` is guarded in both the batch and single paths), and a
+    dict would let an unconverted duplicate mask a converted one.
+    """
+    import ast
+    import inspect
+
+    out = {}
+    for node in ast.walk(ast.parse(inspect.getsource(module))):
+        if not isinstance(node, ast.Raise) or not isinstance(node.exc, ast.Call):
+            continue
+        func = node.exc.func
+        name = getattr(func, "id", None) or getattr(func, "attr", None)
+        for arg in node.exc.args:
+            if isinstance(arg, ast.Constant) and isinstance(arg.value, str):
+                out.setdefault(arg.value, set()).add(name)
+            elif isinstance(arg, ast.JoinedStr):
+                lead = "".join(
+                    v.value
+                    for v in arg.values
+                    if isinstance(v, ast.Constant) and isinstance(v.value, str)
+                )
+                if lead:
+                    out.setdefault(lead, set()).add(name)
+    return out
+
+
+def test_guards_and_argument_errors_raise_the_right_types():
+    # Regression guard for THIS change: the --to-video checks protect an
+    # output-root escape and the render checks stop a pipeline treating an
+    # empty render as success, so both must keep raising SystemExit rather
+    # than being swept up as ordinary argument errors by the new wrapper.
+    # The argument errors that DID move must be ValueError.
+    from zyra.visualization import cli_animate, cli_sos, cli_vector
+
+    animate = _raise_kinds(cli_animate)
+    assert animate[
+        "--to-video cannot start with '-' (may be interpreted as an option)"
+    ] == {"SystemExit"}
+    assert animate["--to-video is outside of allowed output root"] == {"SystemExit"}
+    assert animate["ffmpeg grid composition failed"] == {"SystemExit"}
+
+    sos = _raise_kinds(cli_sos)
+    assert sos["Failed to render SOS frame from "] == {"SystemExit"}
+    assert sos["Failed to render  SOS frame(s): "] == {"SystemExit"}
+
+    for mod in (cli_animate, cli_vector, cli_sos):
+        kinds = _raise_kinds(mod)
+        assert kinds["--output-dir is required when using --inputs"] == {
+            "ValueError"
+        }, mod.__name__
+    assert sos["--input or --inputs is required"] == {"ValueError"}
+    assert sos["--output is required when using --input"] == {"ValueError"}

--- a/tests/cli/test_batch_inputs_extend.py
+++ b/tests/cli/test_batch_inputs_extend.py
@@ -289,3 +289,10 @@ def test_guards_and_argument_errors_raise_the_right_types():
         }, mod.__name__
     assert sos["--input or --inputs is required"] == {"ValueError"}
     assert sos["--output is required when using --input"] == {"ValueError"}
+
+    # cli_vector's docstring states it raises no SystemExit of its own.
+    # Assert that rather than trusting the prose: adding one later would
+    # make the docstring wrong with nothing to catch it.
+    assert "SystemExit" not in set().union(
+        *_raise_kinds(cli_vector).values()
+    ), "cli_vector gained a SystemExit; its handler docstring now lies"

--- a/tests/cli/test_batch_inputs_extend.py
+++ b/tests/cli/test_batch_inputs_extend.py
@@ -11,6 +11,10 @@ occurrence, so the API path silently kept only the LAST input — an API
 caller posting a frame sequence got a successful run that processed one
 file, with nothing in the response to say so. ``action="extend"``
 accepts both styles.
+
+The second half of this file pins the argument-error exit-code contract
+shared by the batch handlers: argument errors are a logged exit 2, while
+runtime failures and the ``--to-video`` path guards stay ``SystemExit``.
 """
 
 from __future__ import annotations
@@ -48,8 +52,8 @@ def _parse(domain, argv):
 
 # (domain, argv prefix before --inputs, argv suffix after the inputs)
 BATCH_COMMANDS = [
-    # heatmap still declares --input required=True on this branch; passing
-    # it keeps the case about --inputs expansion, not that requirement.
+    # heatmap accepts --input alongside --inputs (batch wins), so passing
+    # it keeps this case about --inputs expansion either way.
     ("visualize", ["heatmap", "--input", "x.tif"], ["--output-dir", "out"]),
     ("visualize", ["contour"], ["--output-dir", "out"]),
     ("visualize", ["vector"], []),

--- a/tests/visualization/test_sos.py
+++ b/tests/visualization/test_sos.py
@@ -45,8 +45,10 @@ def test_sos_requires_input_or_inputs():
     from zyra.visualization.cli_sos import handle_sos
 
     ns = SimpleNamespace(inputs=None, input=None, output=None)
-    with pytest.raises(SystemExit):
-        handle_sos(ns)
+    # Argument errors are a logged exit 2, not a raised SystemExit: the
+    # handler now uses the same ValueError contract as heatmap/contour.
+    # Render failures still raise (see the render-failure tests below).
+    assert handle_sos(ns) == 2
 
 
 def test_sos_requires_output_dir_for_batch():
@@ -55,8 +57,7 @@ def test_sos_requires_output_dir_for_batch():
     from zyra.visualization.cli_sos import handle_sos
 
     ns = SimpleNamespace(inputs=["a.npy"], output_dir=None)
-    with pytest.raises(SystemExit):
-        handle_sos(ns)
+    assert handle_sos(ns) == 2
 
 
 def test_sos_single_render_failure_exits_nonzero(tmp_path, monkeypatch):


### PR DESCRIPTION
Completes the exit-code half of the batch work already in `staging`, so it can ship with the same release rather than trailing it.

## Problem

`heatmap` and `contour` raise `ValueError` for argument errors, which their handler wrappers turn into a logged message and **exit 2**. `animate`, `vector`, and `sos` raised `SystemExit` with a bare string — **exit 1**, no logged-error path. The same mistake produced a different exit code depending on which command you ran, which matters for anything scripting against these.

## Five sites, not twelve

There are twelve `SystemExit` raises across the three files. Only five are argument errors:

| file | message | now |
|---|---|---|
| `cli_animate` | `--output-dir is required when using --inputs` | `ValueError` |
| `cli_vector` | `--output-dir is required when using --inputs` | `ValueError` |
| `cli_sos` | `--output-dir is required when using --inputs` | `ValueError` |
| `cli_sos` | `--input or --inputs is required` | `ValueError` |
| `cli_sos` | `--output is required when using --input` | `ValueError` |

The other seven stay `SystemExit` deliberately:

| file | message | why |
|---|---|---|
| `cli_animate` ×2 | `--to-video cannot start with '-'` | argv-injection guard |
| `cli_animate` ×2 | `--to-video is outside of allowed output root` | **output-root escape guard** |
| `cli_animate` | `ffmpeg grid composition failed` | runtime failure |
| `cli_sos` ×2 | `Failed to render … frame(s)` | stops a pipeline treating an empty render as success |

A blanket conversion of all twelve — the obvious reading of "fix the exit codes" — would have re-typed two path-escape guards as ordinary argument errors. That's the reason for the split, and it's what the new test locks down.

## Pre-existing tests that asserted the old behavior

`tests/visualization/test_sos.py` had two tests doing `pytest.raises(SystemExit)` on converted errors — they encoded the bug. Both now assert `handle_sos(ns) == 2`. Flagging explicitly since changing existing assertions deserves a second look; the render-failure tests in the same file are untouched and still assert `SystemExit`.

## Testing

Six new tests: `--inputs` without `--output-dir` exits 2 with no traceback for all three commands, plus both `sos` single-mode argument errors.

The guard test is **AST-based and mutation-checked in both directions**:

```
security guard converted (1st of 2 occurrences)  rc=1 DETECTED
argument error reverted                          rc=1 DETECTED
```

It walks `ast.Raise` nodes rather than grepping source, and keys a **set** of raised types per message — `--to-video` is guarded in two separate code paths, and a plain dict let the unconverted copy mask a converted one. Three earlier versions of this test passed vacuously (a substring match leaking from a neighbouring raise, and a CLI invocation that never reached the guard at all before dying on an unrelated `TypeError`); the mutation check is what caught each.

`tests/cli tests/visualization tests/processing` → **266 passed, 29 skipped**. ruff clean. No manifest or OpenAPI change — handler internals only, the parser surface is untouched.

## Unrelated bug noticed

`zyra visualize animate --input <missing.nc>` dies with `TypeError: expected str, bytes or os.PathLike object, not NoneType` instead of a clean error. Pre-existing, out of scope here, worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G1ZEw6d1yXepDb819YVNRP

---
_Generated by [Claude Code](https://claude.ai/code/session_01G1ZEw6d1yXepDb819YVNRP)_