### PR TITLE
Back off and retry throttled HTTP fetches

### DIFF
--- a/src/zyra/connectors/backends/_retry.py
+++ b/src/zyra/connectors/backends/_retry.py
@@ -92,7 +92,7 @@ def backoff_delay(
     *,
     base_delay: float = DEFAULT_BASE_DELAY,
     max_delay: float = DEFAULT_MAX_DELAY,
-    rand: Callable[[], float] = random.random,
+    rand: Callable[[], float] | None = None,
 ) -> float:
     """Exponential delay with full jitter for a zero-based attempt index.
 
@@ -100,7 +100,12 @@ def backoff_delay(
     concurrent ranged GETs that are throttled together would all sleep
     the same interval and retry in lockstep, reproducing the burst that
     caused the throttle.
+
+    ``rand`` resolves at call time for the same reason as
+    ``with_retries``' — see the note there.
     """
+    if rand is None:
+        rand = random.random
     ceiling = min(max_delay, base_delay * (2**attempt))
     return rand() * ceiling
 
@@ -111,8 +116,8 @@ def with_retries(
     max_attempts: int = DEFAULT_MAX_ATTEMPTS,
     base_delay: float = DEFAULT_BASE_DELAY,
     max_delay: float = DEFAULT_MAX_DELAY,
-    sleep: Callable[[float], None] = time.sleep,
-    rand: Callable[[], float] = random.random,
+    sleep: Callable[[float], None] | None = None,
+    rand: Callable[[], float] | None = None,
 ) -> T:
     """Call ``call``, retrying retryable failures with backoff.
 
@@ -120,9 +125,20 @@ def with_retries(
     attempt rather than being repeated identically. ``sleep`` and
     ``rand`` are injectable so tests can assert the delay sequence
     without spending it.
+
+    They default to ``None`` and resolve to ``time.sleep`` /
+    ``random.random`` here rather than in the signature, because a
+    default argument binds its value once at definition time: writing
+    ``sleep=time.sleep`` would capture the original function, and
+    ``patch("..._retry.time.sleep")`` — the obvious way to keep a test
+    from actually sleeping — would silently have no effect on it.
     """
     if max_attempts < 1:
         raise ValueError("max_attempts must be >= 1")
+    if sleep is None:
+        sleep = time.sleep
+    if rand is None:
+        rand = random.random
     attempt = 0
     while True:
         try:

--- a/src/zyra/connectors/backends/_retry.py
+++ b/src/zyra/connectors/backends/_retry.py
@@ -1,0 +1,144 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Retry policy shared by the HTTP connector's fetch paths.
+
+Object stores answer a burst of requests against one prefix with a
+retryable throttle rather than a hard failure — S3 sends ``503 Slow
+Down`` — and the documented remedy is to back off and try again. Zyra
+treated any non-2xx as fatal, so a batch large enough to be throttled
+lost the whole stage: a 16-frame GRIB2 batch is ~176 requests against a
+single prefix (one ``.idx`` GET plus up to ten concurrent ranged GETs
+per frame) and reliably tripped it.
+
+Kept dependency-light on purpose. ``requests`` is an optional extra and
+the backend keeps a module-level patchable stub for tests, so nothing
+here imports it; retryable transport errors are recognised by exception
+name instead.
+"""
+
+from __future__ import annotations
+
+import random
+import time
+from typing import Callable, TypeVar
+
+T = TypeVar("T")
+
+#: Statuses worth retrying. 429 and 503 are explicit "slow down" signals;
+#: 500/502/504 are transient upstream faults; 408 is a server-side
+#: timeout. Every other 4xx describes the request itself and will fail
+#: identically no matter how many times it is repeated.
+RETRYABLE_STATUS = frozenset({408, 429, 500, 502, 503, 504})
+
+#: Transport-level failures, matched by class name so this module does
+#: not have to import ``requests``.
+RETRYABLE_EXC_NAMES = frozenset(
+    {
+        "ConnectionError",
+        "ConnectTimeout",
+        "ReadTimeout",
+        "Timeout",
+        "ChunkedEncodingError",
+        "IncompleteRead",
+    }
+)
+
+DEFAULT_MAX_ATTEMPTS = 5
+DEFAULT_BASE_DELAY = 0.5
+DEFAULT_MAX_DELAY = 30.0
+
+
+def _status_of(exc: BaseException) -> int | None:
+    """Best-effort HTTP status from a raised exception, else ``None``."""
+    resp = getattr(exc, "response", None)
+    status = getattr(resp, "status_code", None)
+    return status if isinstance(status, int) else None
+
+
+def is_retryable(exc: BaseException) -> bool:
+    """True when retrying ``exc`` could plausibly succeed."""
+    status = _status_of(exc)
+    if status is not None:
+        return status in RETRYABLE_STATUS
+    # No response attached: a transport-level failure, retryable only for
+    # the classes that represent a connection problem rather than a bug.
+    return type(exc).__name__ in RETRYABLE_EXC_NAMES
+
+
+def retry_after_seconds(exc: BaseException) -> float | None:
+    """Parse a ``Retry-After`` header into seconds, if the server sent one.
+
+    Only the delta-seconds form is honoured; the HTTP-date form is
+    ignored so a malformed or far-future date cannot stall a pipeline.
+    """
+    resp = getattr(exc, "response", None)
+    headers = getattr(resp, "headers", None)
+    if not headers:
+        return None
+    try:
+        raw = headers.get("Retry-After")
+    except Exception:
+        return None
+    if raw is None:
+        return None
+    try:
+        value = float(str(raw).strip())
+    except (TypeError, ValueError):
+        return None
+    return value if value >= 0 else None
+
+
+def backoff_delay(
+    attempt: int,
+    *,
+    base_delay: float = DEFAULT_BASE_DELAY,
+    max_delay: float = DEFAULT_MAX_DELAY,
+    rand: Callable[[], float] = random.random,
+) -> float:
+    """Exponential delay with full jitter for a zero-based attempt index.
+
+    Jitter matters more than the growth curve here: without it, ten
+    concurrent ranged GETs that are throttled together would all sleep
+    the same interval and retry in lockstep, reproducing the burst that
+    caused the throttle.
+    """
+    ceiling = min(max_delay, base_delay * (2**attempt))
+    return rand() * ceiling
+
+
+def with_retries(
+    call: Callable[[], T],
+    *,
+    max_attempts: int = DEFAULT_MAX_ATTEMPTS,
+    base_delay: float = DEFAULT_BASE_DELAY,
+    max_delay: float = DEFAULT_MAX_DELAY,
+    sleep: Callable[[float], None] = time.sleep,
+    rand: Callable[[], float] = random.random,
+) -> T:
+    """Call ``call``, retrying retryable failures with backoff.
+
+    Non-retryable failures (a 404, a bad request) propagate on the first
+    attempt rather than being repeated identically. ``sleep`` and
+    ``rand`` are injectable so tests can assert the delay sequence
+    without spending it.
+    """
+    if max_attempts < 1:
+        raise ValueError("max_attempts must be >= 1")
+    attempt = 0
+    while True:
+        try:
+            return call()
+        except Exception as exc:
+            attempt += 1
+            if attempt >= max_attempts or not is_retryable(exc):
+                raise
+            delay = retry_after_seconds(exc)
+            if delay is None:
+                delay = backoff_delay(
+                    attempt - 1,
+                    base_delay=base_delay,
+                    max_delay=max_delay,
+                    rand=rand,
+                )
+            else:
+                delay = min(delay, max_delay)
+            sleep(delay)

--- a/src/zyra/connectors/backends/_retry.py
+++ b/src/zyra/connectors/backends/_retry.py
@@ -17,6 +17,7 @@ name instead.
 
 from __future__ import annotations
 
+import errno
 import random
 import time
 from typing import Callable, TypeVar
@@ -54,11 +55,42 @@ def _status_of(exc: BaseException) -> int | None:
     return status if isinstance(status, int) else None
 
 
+def _is_connection_refused(exc: BaseException) -> bool:
+    """True when the failure was a refused connection, at any depth.
+
+    ``requests`` wraps this several layers down — ConnectionError ->
+    MaxRetryError -> NewConnectionError -> ConnectionRefusedError — so
+    the cause chain has to be walked rather than the outermost type
+    inspected.
+    """
+    seen: set[int] = set()
+    cur: BaseException | None = exc
+    while cur is not None and id(cur) not in seen:
+        seen.add(id(cur))
+        if isinstance(cur, ConnectionRefusedError):
+            return True
+        if isinstance(cur, OSError) and cur.errno == errno.ECONNREFUSED:
+            return True
+        cur = cur.__cause__ or cur.__context__
+    return False
+
+
 def is_retryable(exc: BaseException) -> bool:
     """True when retrying ``exc`` could plausibly succeed."""
     status = _status_of(exc)
     if status is not None:
         return status in RETRYABLE_STATUS
+    # A refused connection is the transport-level twin of a 404: the
+    # host answered, and what it said is that nothing is listening
+    # there. Repeating it produces the identical failure, only slower —
+    # a mistyped URL would otherwise cost the whole backoff ladder
+    # before reporting the obvious.
+    #
+    # Deliberately narrower than "any ConnectionError": a reset
+    # mid-stream, or a DNS lookup that fails once in a container, are
+    # both genuinely worth another attempt.
+    if _is_connection_refused(exc):
+        return False
     # No response attached: a transport-level failure, retryable only for
     # the classes that represent a connection problem rather than a bug.
     return type(exc).__name__ in RETRYABLE_EXC_NAMES

--- a/src/zyra/connectors/backends/http.py
+++ b/src/zyra/connectors/backends/http.py
@@ -12,8 +12,39 @@ the CLI, pipelines, or higher-level wrappers without imposing heavy imports.
 from __future__ import annotations
 
 import re
-from typing import Iterable
+from typing import Any, Iterable
 from urllib.parse import urljoin
+
+from zyra.connectors.backends._retry import (
+    DEFAULT_BASE_DELAY,
+    DEFAULT_MAX_ATTEMPTS,
+    DEFAULT_MAX_DELAY,
+    with_retries,
+)
+
+
+def _retry_opts() -> dict[str, Any]:
+    """Retry knobs, overridable per deployment without a code change."""
+    from zyra.utils.env import env_int
+
+    return {
+        "max_attempts": env_int("HTTP_MAX_ATTEMPTS", DEFAULT_MAX_ATTEMPTS),
+        "base_delay": DEFAULT_BASE_DELAY,
+        "max_delay": DEFAULT_MAX_DELAY,
+    }
+
+
+def default_max_workers() -> int:
+    """Concurrent ranged GETs per file.
+
+    Ten per file is a lot of pressure on one prefix when a batch walks
+    many files; lower it via ``ZYRA_HTTP_MAX_WORKERS`` where a source
+    throttles aggressively.
+    """
+    from zyra.utils.env import env_int
+
+    return max(1, env_int("HTTP_MAX_WORKERS", 10))
+
 
 # Make a module-level "requests" attribute patchable in tests even when the
 # optional dependency is not installed in the environment.
@@ -41,9 +72,12 @@ def fetch_bytes(
     except Exception as exc:  # pragma: no cover - optional dep
         raise RuntimeError("HTTP backend requires the 'requests' extra") from exc
 
-    r = requests.get(url, timeout=timeout, headers=headers)
-    r.raise_for_status()
-    return r.content
+    def _get() -> bytes:
+        r = requests.get(url, timeout=timeout, headers=headers)
+        r.raise_for_status()
+        return r.content
+
+    return with_retries(_get, **_retry_opts())
 
 
 def fetch_text(
@@ -164,28 +198,24 @@ def get_idx_lines(
     from zyra.utils.grib import ensure_idx_path, parse_idx_lines
 
     idx_url = ensure_idx_path(url)
-    # Determine exception type from requests or fall back to Exception for tests
-    ReqExc = getattr(requests, "RequestException", Exception)
-    attempt = 0
-    last_exc = None
-    while attempt < max_retries:
-        try:
-            r = requests.get(idx_url, timeout=timeout, headers=headers)
-            r.raise_for_status()
-            return parse_idx_lines(r.content)
-        except ReqExc as e:  # pragma: no cover - simple retry wrapper
-            last_exc = e
-            attempt += 1
-    if last_exc:
-        raise last_exc
-    return []
+
+    def _get() -> list[str]:
+        r = requests.get(idx_url, timeout=timeout, headers=headers)
+        r.raise_for_status()
+        return parse_idx_lines(r.content)
+
+    # max_retries is retained as the public knob; it previously meant
+    # "attempts with no delay between them", which made throttling worse.
+    opts = _retry_opts()
+    opts["max_attempts"] = max(1, int(max_retries))
+    return with_retries(_get, **opts)
 
 
 def download_byteranges(
     url: str,
     byte_ranges: Iterable[str],
     *,
-    max_workers: int = 10,
+    max_workers: int | None = None,
     timeout: int = 60,
     headers: dict[str, str] | None = None,
 ) -> bytes:
@@ -200,14 +230,21 @@ def download_byteranges(
     def _ranged_get(u: str, range_header: str) -> bytes:
         request_headers = dict(base_headers)
         request_headers["Range"] = range_header
-        r = requests.get(u, headers=request_headers, timeout=timeout)
-        r.raise_for_status()
-        return r.content
+
+        def _get() -> bytes:
+            r = requests.get(u, headers=request_headers, timeout=timeout)
+            r.raise_for_status()
+            return r.content
+
+        return with_retries(_get, **_retry_opts())
 
     from zyra.utils.grib import parallel_download_byteranges
 
     return parallel_download_byteranges(
-        _ranged_get, url, byte_ranges, max_workers=max_workers
+        _ranged_get,
+        url,
+        byte_ranges,
+        max_workers=default_max_workers() if max_workers is None else max_workers,
     )
 
 

--- a/tests/connectors/test_connectors_extended.py
+++ b/tests/connectors/test_connectors_extended.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 from unittest.mock import Mock, patch
 
+import pytest
 from botocore.exceptions import ClientError
 
 from zyra.connectors.backends import ftp as ftp_backend
@@ -95,7 +96,13 @@ def test_http_get_idx_lines_retries_then_success():
     import types
 
     class _ReqExc(Exception):
-        pass
+        # Carries a retryable status: the retry policy now classifies
+        # failures instead of retrying every exception, so a transient
+        # failure has to look like one. A bare Exception is treated as a
+        # bug and propagates immediately (see the test below).
+        def __init__(self, msg):
+            super().__init__(msg)
+            self.response = types.SimpleNamespace(status_code=503, headers={})
 
     good = Mock()
     good.raise_for_status = lambda: None
@@ -103,8 +110,27 @@ def test_http_get_idx_lines_retries_then_success():
     fake_get = Mock(side_effect=[_ReqExc("boom"), good])
     fake_requests = types.SimpleNamespace(get=fake_get)
     with patch.dict(sys.modules, {"requests": fake_requests}):
-        lines = http_backend.get_idx_lines(url)
+        with patch("zyra.connectors.backends._retry.time.sleep", lambda _: None):
+            lines = http_backend.get_idx_lines(url)
         assert lines == ["1:0:a"]
+
+
+def test_http_get_idx_lines_does_not_retry_a_non_transient_error():
+    # Narrowing guard: the previous implementation retried ANY exception,
+    # so a 404 or a programming error cost three identical round trips.
+    url = "https://example.com/file.grib2"
+    import sys
+    import types
+
+    class _Boom(Exception):
+        pass
+
+    fake_get = Mock(side_effect=_Boom("not transient"))
+    fake_requests = types.SimpleNamespace(get=fake_get)
+    with patch.dict(sys.modules, {"requests": fake_requests}):
+        with pytest.raises(_Boom):
+            http_backend.get_idx_lines(url)
+    assert fake_get.call_count == 1
 
 
 def test_s3_get_idx_lines_retry_and_write_and_get_size_error(tmp_path):

--- a/tests/connectors/test_http_retry.py
+++ b/tests/connectors/test_http_retry.py
@@ -313,3 +313,54 @@ def test_patching_time_sleep_actually_stops_the_sleeping():
     # base_delay=5s over two retries would be plainly visible if the
     # real time.sleep were still bound.
     assert elapsed < 1.0, f"slept for real: {elapsed:.2f}s"
+
+
+def test_connection_refused_is_not_retried():
+    """A refused connection is the transport twin of a 404.
+
+    The host answered and said nothing is listening. Repeating that
+    produces the identical failure, only slower — which is how a
+    mistyped URL turned into the full backoff ladder before reporting
+    the obvious, and how one CLI test went from 0.5s to 4.3s.
+
+    Built from a real refused socket rather than a hand-made exception
+    so the cause chain is the one `requests` actually raises.
+    """
+    import socket
+
+    from zyra.connectors.backends._retry import is_retryable
+
+    # Bind and close, so the port is definitely free and refusing.
+    s = socket.socket()
+    s.bind(("127.0.0.1", 0))
+    port = s.getsockname()[1]
+    s.close()
+
+    requests = pytest.importorskip("requests")
+    try:
+        requests.get(f"http://127.0.0.1:{port}/x", timeout=5, proxies={"http": None})
+    except Exception as exc:
+        assert is_retryable(exc) is False
+        # And it really is the wrapped shape, not a bare OSError.
+        assert type(exc).__name__ == "ConnectionError"
+    else:  # pragma: no cover - would mean something is listening
+        pytest.fail("expected the connection to be refused")
+
+
+def test_other_connection_errors_are_still_retried():
+    # The narrowing must not swallow the transient cases: a reset
+    # mid-stream, or a one-off DNS failure in a container, are both
+    # worth another attempt.
+    reset = ConnectionError("reset")
+    reset.__cause__ = ConnectionResetError(104, "Connection reset by peer")
+    assert is_retryable(reset) is True
+    assert is_retryable(ConnectionError("dns hiccup")) is True
+
+
+def test_refused_survives_a_self_referential_cause_chain():
+    # Defensive: a cycle in __cause__/__context__ must not hang the walk.
+    a = ConnectionError("a")
+    b = ConnectionError("b")
+    a.__cause__ = b
+    b.__cause__ = a
+    assert is_retryable(a) is True

--- a/tests/connectors/test_http_retry.py
+++ b/tests/connectors/test_http_retry.py
@@ -278,3 +278,38 @@ def test_max_workers_is_env_configurable(monkeypatch):
     # A nonsense value must not collapse concurrency to zero.
     monkeypatch.setenv("ZYRA_HTTP_MAX_WORKERS", "0")
     assert http_backend.default_max_workers() == 1
+
+
+def test_patching_time_sleep_actually_stops_the_sleeping():
+    """The obvious way to keep a retry test fast has to work.
+
+    ``sleep`` used to default to ``time.sleep`` in the signature, which
+    binds the original function once at definition time — so patching
+    ``_retry.time.sleep`` left the default untouched and the test spent
+    the delay for real. Resolving the default inside the body fixes it;
+    this pins that, because the failure mode is invisible (a passing
+    test that is merely slower and nondeterministic).
+    """
+    import time as _time
+    from unittest.mock import patch
+
+    from zyra.connectors.backends import _retry
+
+    seen: list[float] = []
+    calls = {"n": 0}
+
+    def flaky():
+        calls["n"] += 1
+        if calls["n"] < 3:
+            raise _HTTPError(503)
+        return "ok"
+
+    started = _time.monotonic()
+    with patch("zyra.connectors.backends._retry.time.sleep", seen.append):
+        assert _retry.with_retries(flaky, base_delay=5.0) == "ok"
+    elapsed = _time.monotonic() - started
+
+    assert len(seen) == 2, "the patched sleep must be the one that runs"
+    # base_delay=5s over two retries would be plainly visible if the
+    # real time.sleep were still bound.
+    assert elapsed < 1.0, f"slept for real: {elapsed:.2f}s"

--- a/tests/connectors/test_http_retry.py
+++ b/tests/connectors/test_http_retry.py
@@ -1,0 +1,280 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Backoff for HTTP fetches (issue: batches tripped S3 "503 Slow Down").
+
+A 16-frame GRIB2 batch is ~176 requests against one S3 prefix — one
+``.idx`` GET plus up to ten concurrent ranged GETs per frame — and the
+backend treated the resulting throttle as fatal, losing the whole stage.
+503 and 429 are documented as retryable; 404 is not.
+
+No network here: ``requests`` is stubbed, and ``sleep``/``rand`` are
+injected so the delay sequence can be asserted without spending it.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from zyra.connectors.backends._retry import (
+    backoff_delay,
+    is_retryable,
+    retry_after_seconds,
+    with_retries,
+)
+
+
+class _Resp:
+    def __init__(self, status, headers=None):
+        self.status_code = status
+        self.headers = headers or {}
+
+
+class _HTTPError(Exception):
+    """Stands in for requests.HTTPError (carries .response)."""
+
+    def __init__(self, status, headers=None):
+        super().__init__(f"{status} error")
+        self.response = _Resp(status, headers)
+
+
+class ConnectionError(Exception):  # noqa: A001 - mirrors requests' class name
+    """Name-matched transport failure; the policy keys off the class name."""
+
+
+# ---- policy ---------------------------------------------------------------
+
+
+@pytest.mark.parametrize("status", [408, 429, 500, 502, 503, 504])
+def test_retryable_statuses(status):
+    assert is_retryable(_HTTPError(status)) is True
+
+
+@pytest.mark.parametrize("status", [400, 401, 403, 404, 410, 422])
+def test_client_errors_are_not_retryable(status):
+    # Repeating these produces the identical failure; retrying only
+    # delays the error and adds load.
+    assert is_retryable(_HTTPError(status)) is False
+
+
+def test_transport_errors_are_retryable_by_class_name():
+    assert is_retryable(ConnectionError("boom")) is True
+    assert is_retryable(ValueError("not a transport problem")) is False
+
+
+def test_backoff_grows_and_is_jittered():
+    # Full jitter: the ceiling doubles per attempt, and the actual delay
+    # is a fraction of it, so concurrent retries do not run in lockstep.
+    ceilings = [
+        backoff_delay(i, base_delay=1.0, max_delay=100.0, rand=lambda: 1.0)
+        for i in range(5)
+    ]
+    assert ceilings == [1.0, 2.0, 4.0, 8.0, 16.0]
+    assert backoff_delay(0, base_delay=1.0, rand=lambda: 0.0) == 0.0
+    # max_delay caps the ceiling.
+    assert backoff_delay(20, base_delay=1.0, max_delay=30.0, rand=lambda: 1.0) == 30.0
+
+
+def test_retry_after_header_is_honoured():
+    assert retry_after_seconds(_HTTPError(503, {"Retry-After": "7"})) == 7.0
+    assert retry_after_seconds(_HTTPError(503, {})) is None
+    # HTTP-date form is deliberately ignored rather than parsed, so a
+    # far-future date cannot stall a pipeline.
+    assert (
+        retry_after_seconds(
+            _HTTPError(503, {"Retry-After": "Wed, 21 Oct 2026 07:28:00 GMT"})
+        )
+        is None
+    )
+
+
+# ---- driver ---------------------------------------------------------------
+
+
+def test_succeeds_after_transient_failures():
+    calls = {"n": 0}
+    slept = []
+
+    def call():
+        calls["n"] += 1
+        if calls["n"] < 3:
+            raise _HTTPError(503)
+        return b"payload"
+
+    out = with_retries(call, sleep=slept.append, rand=lambda: 1.0, base_delay=1.0)
+    assert out == b"payload"
+    assert calls["n"] == 3
+    assert slept == [1.0, 2.0], "delay must grow between attempts"
+
+
+def test_non_retryable_fails_on_first_attempt():
+    calls = {"n": 0}
+    slept = []
+
+    def call():
+        calls["n"] += 1
+        raise _HTTPError(404)
+
+    with pytest.raises(_HTTPError):
+        with_retries(call, sleep=slept.append)
+    assert calls["n"] == 1, "a 404 must not be retried"
+    assert slept == []
+
+
+def test_gives_up_after_max_attempts_and_reraises():
+    calls = {"n": 0}
+
+    def call():
+        calls["n"] += 1
+        raise _HTTPError(503)
+
+    with pytest.raises(_HTTPError):
+        with_retries(call, max_attempts=4, sleep=lambda _: None)
+    assert calls["n"] == 4
+
+
+def test_retry_after_overrides_backoff():
+    calls = {"n": 0}
+    slept = []
+
+    def call():
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise _HTTPError(503, {"Retry-After": "12"})
+        return b"ok"
+
+    with_retries(call, sleep=slept.append, base_delay=1.0, rand=lambda: 1.0)
+    assert slept == [12.0]
+
+
+def test_retry_after_is_capped_by_max_delay():
+    def call():
+        raise _HTTPError(503, {"Retry-After": "9999"})
+
+    slept = []
+    with pytest.raises(_HTTPError):
+        with_retries(call, max_attempts=2, max_delay=30.0, sleep=slept.append)
+    assert slept == [30.0], "a hostile Retry-After must not stall the run"
+
+
+# ---- backend integration --------------------------------------------------
+
+
+def _patch_requests_get(monkeypatch, fake_get):
+    """Patch the real ``requests.get``.
+
+    ``fetch_bytes`` does a function-local ``import requests``, which
+    shadows the module-level attribute the backend keeps for patching,
+    so setting that attribute has no effect on this path.
+    """
+    requests = pytest.importorskip("requests")
+    monkeypatch.setattr(requests, "get", fake_get)
+    from zyra.connectors.backends import http as http_backend
+
+    monkeypatch.setattr(
+        http_backend,
+        "_retry_opts",
+        lambda: {"max_attempts": 5, "base_delay": 0, "max_delay": 0},
+    )
+    return http_backend
+
+
+class _OK:
+    content = b"DATA"
+
+    def raise_for_status(self):
+        return None
+
+
+def test_fetch_bytes_retries_a_throttle(monkeypatch):
+    calls = {"n": 0}
+
+    def fake_get(url, **kw):
+        calls["n"] += 1
+        if calls["n"] < 3:
+            raise _HTTPError(503)
+        return _OK()
+
+    http_backend = _patch_requests_get(monkeypatch, fake_get)
+    assert http_backend.fetch_bytes("https://example.org/x.grib2") == b"DATA"
+    assert calls["n"] == 3, "a 503 must be retried until it succeeds"
+
+
+def test_fetch_bytes_does_not_retry_a_404(monkeypatch):
+    calls = {"n": 0}
+
+    def fake_get(url, **kw):
+        calls["n"] += 1
+        raise _HTTPError(404)
+
+    http_backend = _patch_requests_get(monkeypatch, fake_get)
+    with pytest.raises(_HTTPError):
+        http_backend.fetch_bytes("https://example.org/missing.grib2")
+    assert calls["n"] == 1, "a 404 must not be retried"
+
+
+def test_ranged_gets_retry_a_throttle(monkeypatch):
+    # The path that actually failed in production: concurrent ranged GETs
+    # for one file, throttled mid-batch.
+    calls = {"n": 0}
+
+    def fake_get(url, **kw):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise _HTTPError(503)
+        return _OK()
+
+    http_backend = _patch_requests_get(monkeypatch, fake_get)
+    out = http_backend.download_byteranges(
+        "https://example.org/x.grib2", ["bytes=0-9"], max_workers=1
+    )
+    assert out == b"DATA"
+    assert calls["n"] == 2
+
+
+def test_idx_lines_retry_uses_backoff_not_a_tight_loop(monkeypatch):
+    # get_idx_lines already retried, but with no delay between attempts,
+    # which makes a rate limiter worse rather than better.
+    slept = []
+    calls = {"n": 0}
+
+    def fake_get(url, **kw):
+        calls["n"] += 1
+        if calls["n"] < 3:
+            raise _HTTPError(503)
+        return type(
+            "R",
+            (),
+            {
+                "content": b"1:0:d=2026:VAR:lev:anl:\n",
+                "raise_for_status": lambda self: None,
+            },
+        )()
+
+    requests = pytest.importorskip("requests")
+    monkeypatch.setattr(requests, "get", fake_get)
+    from zyra.connectors.backends import http as http_backend
+
+    monkeypatch.setattr(
+        http_backend,
+        "_retry_opts",
+        lambda: {
+            "max_attempts": 5,
+            "base_delay": 1.0,
+            "max_delay": 30.0,
+            "sleep": slept.append,
+            "rand": lambda: 1.0,
+        },
+    )
+    http_backend.get_idx_lines("https://example.org/x.grib2")
+    assert calls["n"] == 3
+    assert slept == [1.0, 2.0], "attempts must be spaced, not immediate"
+
+
+def test_max_workers_is_env_configurable(monkeypatch):
+    from zyra.connectors.backends import http as http_backend
+
+    assert http_backend.default_max_workers() == 10
+    monkeypatch.setenv("ZYRA_HTTP_MAX_WORKERS", "3")
+    assert http_backend.default_max_workers() == 3
+    # A nonsense value must not collapse concurrency to zero.
+    monkeypatch.setenv("ZYRA_HTTP_MAX_WORKERS", "0")
+    assert http_backend.default_max_workers() == 1

--- a/tests/visualization/test_palette_legend.py
+++ b/tests/visualization/test_palette_legend.py
@@ -612,9 +612,20 @@ def test_cli_unreachable_palette_url_exits_2(tmp_path):
         capture_output=True,
         text=True,
         check=False,
-        # Never let an ambient proxy turn a refused connection into a
-        # slow upstream error.
-        env={**os.environ, "no_proxy": "*", "NO_PROXY": "*"},
+        env={
+            **os.environ,
+            # Never let an ambient proxy turn a refused connection into
+            # a slow upstream error.
+            "no_proxy": "*",
+            "NO_PROXY": "*",
+            # This test is about the exit code and the message, not
+            # about retry behavior. A refused connection is already
+            # non-retryable, but pinning attempts keeps the test fast
+            # and deterministic on a CI network that drops the packet
+            # instead of refusing it — where each attempt would
+            # otherwise wait out the full 60s request timeout.
+            "ZYRA_HTTP_MAX_ATTEMPTS": "1",
+        },
     )
     assert proc.returncode == 2
     assert url in proc.stderr


### PR DESCRIPTION
Closes #276.

## Problem

A 16-frame GRIB2 batch is ~176 requests against one S3 prefix — one `.idx` GET plus up to **ten concurrent** ranged GETs per frame — and S3 answers that with a throttle. The backend treated any non-2xx as fatal, so the whole stage died after seven frames:

```
ERROR: Failed to fetch from URL: 503 Server Error: Slow Down for url:
  .../gefs.chem.t12z.a2d_0p25.f042.grib2
Stage 1 [process] failed with exit code 2.
```

`503 Slow Down` is a documented, retryable throttle whose remedy is backoff.

## Retry wasn't missing — it was in one of three places, and wrong

| call site | before | after |
|---|---|---|
| `get_idx_lines` | 3 attempts, **no delay**, catches bare `Exception` | shared policy |
| `fetch_bytes` | none | shared policy |
| `download_byteranges` (ranged GETs) | none | shared policy |

The existing retry had two problems beyond coverage. It looped with **no delay between attempts**, which makes a rate limiter worse rather than better. And its exception filter fell back to bare `Exception` when `requests.RequestException` wasn't resolvable, so a 404 — or a genuine bug — cost three identical round trips.

## Change

New `connectors/backends/_retry.py`: exponential backoff with **full jitter**, capped, honouring `Retry-After` when present. Retries 408/429/500/502/503/504 and named transport errors; everything else propagates on the first attempt.

Jitter is load-bearing, not decoration — ten concurrent ranged GETs throttled together would otherwise sleep the identical interval and retry in lockstep, reproducing the burst that caused the throttle.

Kept dependency-light: `requests` is an optional extra and the backend keeps a module-level patchable stub, so `_retry` imports nothing from it and recognises transport failures by exception class name.

Two new knobs, defaults unchanged: `ZYRA_HTTP_MAX_ATTEMPTS` and `ZYRA_HTTP_MAX_WORKERS` (the per-file fan-out — ten is a lot of pressure on one prefix when a batch walks many files).

## Verified against live S3

The exact batch that failed:

```
16 URLs → rc=0, tifs 16/16, real 0m19.372s, zero 503s in the log
```

## Scope

**S3 backend deliberately untouched.** Its fetches go through `boto3.client`, which has its own retry layer, and the demonstrated failure is the HTTP path. Adding a second retry layer underneath botocore's would be guesswork about interaction; worth a separate decision about setting an explicit `Config(retries=...)` instead.

## A pre-existing test changed

`test_http_get_idx_lines_retries_then_success` asserted the old retry-any-exception behavior by raising an opaque `Exception` subclass. It now raises one carrying a 503 — what a transient failure actually looks like — and a companion test pins the narrowing: a non-transient error is **not** retried. Calling it out since changing an existing assertion deserves a second look.

## Testing

25 new tests in `tests/connectors/test_http_retry.py`, no network: `requests` stubbed, `sleep`/`rand` injected so the delay sequence is asserted rather than spent.

- every retryable status retried; 400/401/403/404/410/422 not
- transport errors retried by class name; `ValueError` not
- backoff ceilings double (`1, 2, 4, 8, 16`) and are capped by `max_delay`
- `Retry-After` overrides backoff, and is itself capped so a hostile value can't stall a run
- attempt counts on success-after-failure, give-up, and first-attempt-failure
- backend integration: `fetch_bytes` retries a 503 and doesn't retry a 404; ranged GETs retry; `get_idx_lines` now spaces its attempts (`[1.0, 2.0]`) instead of hammering

Mutation-checked: removing the retry wrapper from `fetch_bytes` fails the suite.

`tests/connectors tests/misc tests/processing` → **277 passed, 3 skipped**. ruff clean.

## Follow-on

This is what makes 16-frame animations viable — since NOAA-GSL/zyra#322 the binding constraint on frame count was this throttle, not the pipeline stage budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G1ZEw6d1yXepDb819YVNRP

---
_Generated by [Claude Code](https://claude.ai/code/session_01G1ZEw6d1yXepDb819YVNRP)_