### PR TITLE
Keep notebook-session tests out of the working tree

### DIFF
--- a/tests/notebook/conftest.py
+++ b/tests/notebook/conftest.py
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Keep notebook-session tests out of the working tree.
+
+``NotebookRegistry`` writes ``notebook_capabilities_overlay.json`` and a
+``provenance.sqlite`` under its workdir, and ``_resolve_workdir`` falls
+back to :func:`Path.cwd` when neither an explicit ``workdir`` nor
+``ZYRA_NOTEBOOK_DIR`` is set. A test that builds a session without a
+workdir therefore drops both files into the repository root — so running
+the suite left the tree dirty.
+
+Pinning the env var per test fixes the whole package rather than one call
+site, and keeps a future test from reintroducing it. Nothing here asserts
+the CWD fallback itself, so overriding it costs no coverage.
+
+The two ``setdefault`` calls in ``NotebookRegistry.__init__`` are why the
+env vars are cleared as well: ``setdefault`` will not overwrite, so the
+first session in a process would otherwise pin every later one to its own
+temporary directory.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _isolate_notebook_workdir(tmp_path, monkeypatch):
+    monkeypatch.setenv("ZYRA_NOTEBOOK_DIR", str(tmp_path))
+    monkeypatch.delenv("ZYRA_NOTEBOOK_PROVENANCE", raising=False)
+    monkeypatch.delenv("ZYRA_NOTEBOOK_OVERLAY", raising=False)

--- a/tests/notebook/conftest.py
+++ b/tests/notebook/conftest.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 """Keep notebook-session tests out of the working tree.
 
-``NotebookRegistry`` writes ``notebook_capabilities_overlay.json`` and a
+``Session`` (`zyra.notebook.registry`) writes ``notebook_capabilities_overlay.json`` and a
 ``provenance.sqlite`` under its workdir, and ``_resolve_workdir`` falls
 back to :func:`Path.cwd` when neither an explicit ``workdir`` nor
 ``ZYRA_NOTEBOOK_DIR`` is set. A test that builds a session without a
@@ -12,7 +12,7 @@ Pinning the env var per test fixes the whole package rather than one call
 site, and keeps a future test from reintroducing it. Nothing here asserts
 the CWD fallback itself, so overriding it costs no coverage.
 
-The two ``setdefault`` calls in ``NotebookRegistry.__init__`` are why the
+The two ``setdefault`` calls in ``Session.__init__`` are why the
 env vars are cleared as well: ``setdefault`` will not overwrite, so the
 first session in a process would otherwise pin every later one to its own
 temporary directory.


### PR DESCRIPTION
## The problem

Running the test suite leaves two untracked files in the repository root:

```
?? notebook_capabilities_overlay.json
?? provenance.sqlite
```

`NotebookRegistry` writes both under its workdir, and `_resolve_workdir` falls back to `Path.cwd()` when neither an explicit `workdir` argument nor `ZYRA_NOTEBOOK_DIR` is set. `tests/notebook/test_registry.py:8` calls `create_session()` with no workdir — every other session in that file passes `tmp_path` — so the files land wherever pytest was invoked from.

Reproducible in about 1.5 seconds:

```console
$ python -m pytest tests/notebook/test_registry.py -q
$ git status --short
?? notebook_capabilities_overlay.json
?? provenance.sqlite
```

Harmless to the tests, but it means a clean checkout reports a dirty tree after `pytest`, which is noise in exactly the place you want none.

## The fix

Pin the workdir for the whole package in a `conftest.py` fixture, rather than patching the one call site. The CWD fallback is reachable from any future test, so fixing it at the package boundary stops it there permanently. Nothing in the suite asserts the CWD fallback itself, so overriding it costs no coverage.

The fixture also clears `ZYRA_NOTEBOOK_PROVENANCE` and `ZYRA_NOTEBOOK_OVERLAY`, which `NotebookRegistry.__init__` populates via `os.environ.setdefault` (`registry.py:311-312`). Since `setdefault` will not overwrite, the first session constructed in a process would otherwise pin every later one to its own temporary directory — a cross-test coupling that happens to be invisible today.

## Deliberately not a `.gitignore` entry

Ignoring the paths would hide a recurrence rather than prevent it, and these are legitimate user artifacts when someone genuinely runs a notebook session from a checkout. Better that the tests stop writing them.

## Verification

* `tests/notebook` — 17 passed, 1 skipped.
* Full suite — 835 passed, `git status` clean afterwards. The 2 failures are pre-existing and environmental (missing `samples/demo.npy` fixture; libmagic returning `inode/x-empty` for an empty `.nc`), unrelated to this change and reproducing on a clean tree.
* Removing the fixture reproduces the leak.

`ruff check` and `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G1ZEw6d1yXepDb819YVNRP

---
_Generated by [Claude Code](https://claude.ai/code/session_01G1ZEw6d1yXepDb819YVNRP)_