### PR TITLE
Place the basemap image at its own extent, not the viewport

### DIFF
--- a/src/zyra/visualization/basemap.py
+++ b/src/zyra/visualization/basemap.py
@@ -16,6 +16,7 @@ def add_basemap_cartopy(
     extent: Optional[Iterable[float]] = None,
     *,
     image_path: Optional[str] = None,
+    image_extent: Optional[Iterable[float]] = None,
     features: Optional[Iterable[str]] = None,
     alpha: float = 1.0,
 ):
@@ -26,9 +27,20 @@ def add_basemap_cartopy(
     ax : cartopy.mpl.geoaxes.GeoAxesSubplot
         Target axes with a geographic projection (PlateCarree recommended).
     extent : iterable of float, optional
-        [west, east, south, north] in PlateCarree coordinates.
+        The **viewport**: [west, east, south, north] in PlateCarree
+        coordinates, passed to ``ax.set_extent``.
     image_path : str, optional
         Path to a background image to draw via ``imshow``.
+    image_extent : iterable of float, optional
+        The geographic extent **the image itself covers**, defaulting to
+        the whole globe — which is what every basemap shipped in
+        ``zyra.assets.images`` is (equirectangular, 2:1).
+
+        This is deliberately not ``extent``. Reusing the viewport here
+        stretched a global image into whatever region was being viewed,
+        so a North America viewport rendered the entire world squashed
+        into that box (#284). Cartopy crops the image to the viewport on
+        its own once the image is placed at its true extent.
     features : iterable of str, optional
         Feature names to add: any of {"coastline", "borders", "gridlines"}.
     alpha : float, default=1.0
@@ -51,13 +63,24 @@ def add_basemap_cartopy(
             ax.imshow(
                 img,
                 origin="upper",
-                extent=extent or [-180, 180, -90, 90],
+                extent=image_extent or [-180, 180, -90, 90],
                 transform=ccrs.PlateCarree(),
                 alpha=alpha,
             )
-        except Exception:
-            # Swallow image read failures; caller may still draw data
-            pass
+        except Exception as exc:
+            # Carrying on is right — the caller may still draw data over
+            # a blank background — but doing it silently is not. An
+            # unreadable asset (a Git LFS pointer left unfetched, say)
+            # otherwise renders as a plain white figure with no clue
+            # why, which reads as a bug in the data path.
+            import logging
+
+            logging.warning(
+                "basemap %s could not be drawn (%s: %s); continuing without it",
+                image_path,
+                type(exc).__name__,
+                exc,
+            )
 
     if features:
         for feat in features:

--- a/tests/visualization/test_basemap_extent.py
+++ b/tests/visualization/test_basemap_extent.py
@@ -1,0 +1,118 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Basemap image placement vs. the viewport (#284).
+
+``add_basemap_cartopy`` took one ``extent`` and used it for two
+different things: the viewport handed to ``ax.set_extent``, and the
+geographic extent the background image covers. Those coincide only when
+the view is global, so a regional ``--extent`` stretched the whole world
+into that box — a North America view rendering Eurasia inside it.
+
+The fixtures here build their own basemap rather than using
+``zyra.assets.images``: those are Git LFS-tracked, and a checkout
+without the objects fetched has pointer files that ``imread`` cannot
+parse, which would make these tests pass for the wrong reason.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+pytest.importorskip("cartopy")
+pytest.importorskip("matplotlib")
+
+import matplotlib  # noqa: E402
+
+matplotlib.use("Agg")
+
+import cartopy.crs as ccrs  # noqa: E402
+import matplotlib.pyplot as plt  # noqa: E402
+from matplotlib import image as mpimg  # noqa: E402
+
+from zyra.visualization.basemap import add_basemap_cartopy  # noqa: E402
+
+# A North America viewport, in [west, east, south, north].
+VIEWPORT = [-135.0, -60.0, 21.0, 53.0]
+
+
+def _write_global_basemap(path):
+    """A black 1°/px world with a white block over Australia.
+
+    The block sits far outside `VIEWPORT`, which is what makes the
+    assertion a clean boolean: placed correctly the block is off-screen,
+    while squashing the globe into the viewport drags it into frame.
+    """
+    img = np.zeros((180, 360, 3), dtype="uint8")
+    # lon 100..140E, lat 20..60S -> rows/cols in a north-up 1°/px grid.
+    img[110:150, 280:320] = 255
+    mpimg.imsave(str(path), img)
+
+
+def _render(tmp_path, basemap):
+    fig = plt.figure(figsize=(6, 3), dpi=50)
+    ax = fig.add_subplot(1, 1, 1, projection=ccrs.PlateCarree())
+    add_basemap_cartopy(ax, VIEWPORT, image_path=str(basemap))
+    out = tmp_path / "render.png"
+    fig.savefig(out, bbox_inches="tight", pad_inches=0)
+    plt.close(fig)
+    return np.asarray(mpimg.imread(str(out)))[..., :3]
+
+
+def test_regional_viewport_does_not_drag_in_the_whole_globe(tmp_path):
+    basemap = tmp_path / "world.png"
+    _write_global_basemap(basemap)
+
+    rendered = _render(tmp_path, basemap)
+
+    # Rendered floats in 0..1; the marker is pure white.
+    bright = (rendered > 0.9).all(axis=-1).mean()
+    assert bright == 0.0, (
+        "the Australia marker is outside the North America viewport, so it "
+        f"must not appear; {bright:.1%} of the render is white, which means "
+        "the global image was squashed into the viewport"
+    )
+
+
+def test_explicit_image_extent_is_honored(tmp_path):
+    """A caller may declare that the image covers only the viewport.
+
+    This is the case the old code got right by accident, and it has to
+    keep working — an image whose extent genuinely is the viewport
+    should fill the frame.
+    """
+    basemap = tmp_path / "region.png"
+    img = np.full((32, 75, 3), 255, dtype="uint8")
+    mpimg.imsave(str(basemap), img)
+
+    fig = plt.figure(figsize=(6, 3), dpi=50)
+    ax = fig.add_subplot(1, 1, 1, projection=ccrs.PlateCarree())
+    add_basemap_cartopy(ax, VIEWPORT, image_path=str(basemap), image_extent=VIEWPORT)
+    out = tmp_path / "region_render.png"
+    fig.savefig(out, bbox_inches="tight", pad_inches=0)
+    plt.close(fig)
+
+    rendered = np.asarray(mpimg.imread(str(out)))[..., :3]
+    bright = (rendered > 0.9).all(axis=-1).mean()
+    assert (
+        bright > 0.9
+    ), f"image declared at the viewport should fill it, got {bright:.1%}"
+
+
+def test_unreadable_basemap_warns_instead_of_failing_silently(tmp_path, caplog):
+    """An asset that will not parse must say so.
+
+    Git LFS pointer files are the motivating case: `imread` raises, the
+    render comes out blank, and before this the exception was swallowed
+    with no message at all.
+    """
+    bad = tmp_path / "pointer.jpg"
+    bad.write_text("version https://git-lfs.github.com/spec/v1\noid sha256:deadbeef\n")
+
+    fig = plt.figure(figsize=(4, 2), dpi=50)
+    ax = fig.add_subplot(1, 1, 1, projection=ccrs.PlateCarree())
+    with caplog.at_level("WARNING"):
+        add_basemap_cartopy(ax, VIEWPORT, image_path=str(bad))
+    plt.close(fig)
+
+    assert "pointer.jpg" in caplog.text
+    assert "could not be drawn" in caplog.text


### PR DESCRIPTION
Closes #284.

## The bug

`add_basemap_cartopy` took one `extent` and used it for two different things — the viewport handed to `ax.set_extent`, and the geographic extent the background image covers:

```python
extent=extent or [-180, 180, -90, 90],
```

Those coincide only when the view is global. With a regional `--extent`, the whole world was stretched into that box, so a North America viewport rendered Eurasia inside it.

`extent` is the viewport — that has been its documented role since #247. The image's own extent is a separate quantity, and for every basemap shipped in `zyra.assets.images` it is the whole globe (`fv3-chem-basemap.jpg` is 4096×2048, ratio 2.00).

## The fix

Add `image_extent`, defaulting to the globe, and let cartopy crop to the viewport as it already does. A caller with a genuinely non-global image can now say so instead of relying on the accidental coupling.

## Evidence

Markers placed at known coordinates in a synthetic global basemap, rendered through `heatmap` at a North America viewport (`--extent -135 -60 21 53`):

| | marker A | marker B |
|---|---|---|
| expected | lon −129, lat 51 | lon −64, lat 23 |
| **before** | lon −124.4, lat 46.1 | lon −110.9, lat 41.1 |
| **after** | lon −129.0, lat 51.0 | lon −64.0, lat 23.0 |

Before the fix both markers collapse toward the middle of the frame — the signature of the whole globe being squashed into the viewport. After, they land exactly where they belong.

## No current pipeline changes behaviour

Every existing pipeline passes no `--extent` or a global one, and both take the same path as before. Verified rather than assumed — the same markers rendered globally come out at lon −129.1/lat 51.1 and lon −64.1/lat 23.1, unchanged by this commit.

## Also: stop swallowing basemap load failures

The same block caught every exception from `plt.imread` and discarded it. A Git LFS pointer left unfetched raises `UnidentifiedImageError`, and the render came out a plain white figure with no message — which reads as a broken data path rather than a missing asset. It cost me an hour and a wrong diagnosis before I found it.

The fallback behaviour is right (carry on; the caller may still draw data). The silence is not. Now logs a warning naming the path and the error.

## Tests

Three, in a new `tests/visualization/test_basemap_extent.py`. They build their own basemap rather than using the packaged assets — those are LFS-tracked, and on an unfetched checkout `imread` fails, which would make these tests pass for the wrong reason.

* `test_regional_viewport_does_not_drag_in_the_whole_globe` — a marker over Australia, far outside a North America viewport, must not appear. Mutation-checked: restoring `extent=extent or ...` fails it.
* `test_explicit_image_extent_is_honored` — the case the old code got right by accident still works.
* `test_unreadable_basemap_warns_instead_of_failing_silently` — feeds it an actual LFS pointer file.

`tests/visualization/` 97 passed / 28 skipped. Full suite 840 passed, with the same 2 pre-existing environmental failures unrelated to this change. `ruff check` and `ruff format --check` clean.

## Correction to an earlier revision of this description

An earlier version of this text quoted correlation figures (`-0.050` vs `0.998`) from a run where I had passed `--extent` in `--dst-bounds` order (`west south east north` instead of `west east south north`), so the viewport was not the box I intended. Those numbers should be disregarded — the marker measurements above replace them, and were taken with the correct ordering.

The same mistake led me to file #286 against `heatmap`; it is closed as invalid. The flag-ordering collision that caused it is now #287. The defect this PR fixes is unaffected: the code used the viewport as the image's extent regardless of what the viewport was, and the unit tests here have used the correct `[W, E, S, N]` ordering throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G1ZEw6d1yXepDb819YVNRP