### PR TITLE
Wait for the PyPI file, not just the index listing

### DIFF
--- a/scripts/wait_for_pypi.py
+++ b/scripts/wait_for_pypi.py
@@ -32,10 +32,7 @@ def fetch_json(url: str, timeout: float = 10.0) -> dict[str, Any]:
     This validation mitigates SSRF risks when the URL is constructed from
     untrusted input in future refactors.
     """
-    parsed = urlparse(url)
-    if parsed.scheme != "https" or parsed.netloc.lower() != "pypi.org":
-        raise ValueError(f"Refusing to fetch non-PyPI URL: {url}")
-    with urllib.request.urlopen(url, timeout=timeout) as r:
+    with _urlopen(url, "pypi.org", timeout=timeout) as r:
         return json.load(r)
 
 
@@ -57,10 +54,52 @@ def _require_allowed_url(url: str, *hosts: str) -> None:
     Guards against SSRF if a URL ever reaches here from untrusted input.
     ``files.pythonhosted.org`` is allowed alongside ``pypi.org`` because
     the file check below has to follow the index's own links.
+
+    Compares ``hostname`` rather than ``netloc``: netloc carries the port
+    and any userinfo, so an explicit ``https://pypi.org:443/...`` — same
+    host, same default port — would be refused as a stranger. ``hostname``
+    normalises the port away, strips userinfo, and lowercases.
     """
+    allowed = tuple(h.lower() for h in hosts)
     parsed = urlparse(url)
-    if parsed.scheme != "https" or parsed.netloc.lower() not in hosts:
-        raise ValueError(f"Refusing to fetch non-PyPI URL: {url}")
+    if parsed.scheme != "https" or (parsed.hostname or "") not in allowed:
+        raise ValueError(
+            f"Refusing to fetch {url}: not HTTPS on {' or '.join(allowed)}"
+        )
+
+
+class _AllowlistRedirectHandler(urllib.request.HTTPRedirectHandler):
+    """Re-check the allowlist on each redirect hop.
+
+    urllib follows redirects by itself, so validating only the URL we ask
+    for checks the one hop that was never in doubt: a 302 pointing off the
+    allowlist would be followed, and the request issued, before anything
+    looked at it. Checking ``geturl()`` after ``urlopen`` returns is too
+    late for the same reason — by then it has been fetched. Refusing here
+    stops the hop before it goes out.
+    """
+
+    def __init__(self, hosts: tuple[str, ...]) -> None:
+        super().__init__()
+        self._hosts = hosts
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):  # type: ignore[no-untyped-def]
+        _require_allowed_url(newurl, *self._hosts)
+        return super().redirect_request(req, fp, code, msg, headers, newurl)
+
+
+def _urlopen(url_or_req, *hosts: str, timeout: float = 10.0):  # type: ignore[no-untyped-def]
+    """``urlopen`` with the allowlist enforced on the request *and* redirects.
+
+    The single seam every fetch in this module goes through, so the guard
+    cannot be bypassed by adding a call site that forgets it.
+    """
+    target = url_or_req if isinstance(url_or_req, str) else url_or_req.full_url
+    _require_allowed_url(target, *hosts)
+    opener = urllib.request.build_opener(
+        _AllowlistRedirectHandler(tuple(h.lower() for h in hosts))
+    )
+    return opener.open(url_or_req, timeout=timeout)
 
 
 def file_urls_for_version(
@@ -74,8 +113,7 @@ def file_urls_for_version(
     """
     normalized = pep503_normalize(package)
     simple_url = f"https://pypi.org/simple/{normalized}/"
-    _require_allowed_url(simple_url, "pypi.org")
-    with urllib.request.urlopen(simple_url, timeout=timeout) as r:
+    with _urlopen(simple_url, "pypi.org", timeout=timeout) as r:
         html = r.read().decode("utf-8", errors="replace")
 
     # Wheels escape the name with underscores (PEP 427); sdists use the
@@ -106,9 +144,8 @@ def is_fetchable(url: str, timeout: float = 10.0) -> bool:
     "downloadable" are separate facts, and only the second one is the
     condition a build actually needs.
     """
-    _require_allowed_url(url, FILES_HOST, "pypi.org")
     req = urllib.request.Request(url, headers={"Range": "bytes=0-0"})
-    with urllib.request.urlopen(req, timeout=timeout) as r:
+    with _urlopen(req, FILES_HOST, "pypi.org", timeout=timeout) as r:
         return r.status in (200, 206)
 
 

--- a/scripts/wait_for_pypi.py
+++ b/scripts/wait_for_pypi.py
@@ -15,6 +15,7 @@ Exits with code 0 when the version is available, 1 on timeout or error.
 from __future__ import annotations
 
 import json
+import re
 import socket
 import sys
 import time
@@ -22,7 +23,7 @@ import urllib.request
 from json import JSONDecodeError
 from typing import Any
 from urllib.error import HTTPError, URLError
-from urllib.parse import urlparse
+from urllib.parse import unquote, urljoin, urlparse
 
 
 def fetch_json(url: str, timeout: float = 10.0) -> dict[str, Any]:
@@ -45,22 +46,83 @@ def pep503_normalize(name: str) -> str:
     return re.sub(r"[-_.]+", "-", name).lower()
 
 
-def is_version_available(package: str, version: str, timeout: float = 10.0) -> bool:
-    """Check PyPI Simple API for availability of a specific version.
+#: Host serving the actual distribution files. The simple index lives on
+#: pypi.org and links out to here, and the two propagate independently.
+FILES_HOST = "files.pythonhosted.org"
 
-    Uses the PEP 503 simple index HTML, which pip consults when installing.
-    Returns True if any file link appears to contain the version string.
+
+def _require_allowed_url(url: str, *hosts: str) -> None:
+    """Reject anything not HTTPS on one of ``hosts``.
+
+    Guards against SSRF if a URL ever reaches here from untrusted input.
+    ``files.pythonhosted.org`` is allowed alongside ``pypi.org`` because
+    the file check below has to follow the index's own links.
+    """
+    parsed = urlparse(url)
+    if parsed.scheme != "https" or parsed.netloc.lower() not in hosts:
+        raise ValueError(f"Refusing to fetch non-PyPI URL: {url}")
+
+
+def file_urls_for_version(
+    package: str, version: str, timeout: float = 10.0
+) -> list[str]:
+    """Return the simple index's file links for exactly ``version``.
+
+    The match is anchored on the full filename rather than a substring:
+    a bare ``<pkg>-<version>`` needle also matches ``0.1.53.1``, which
+    would let a *different* release satisfy the wait.
     """
     normalized = pep503_normalize(package)
     simple_url = f"https://pypi.org/simple/{normalized}/"
-    parsed = urlparse(simple_url)
-    if parsed.scheme != "https" or parsed.netloc.lower() != "pypi.org":
-        raise ValueError(f"Refusing to fetch non-PyPI URL: {simple_url}")
+    _require_allowed_url(simple_url, "pypi.org")
     with urllib.request.urlopen(simple_url, timeout=timeout) as r:
         html = r.read().decode("utf-8", errors="replace")
-    # Look for filename prefix like '<pkg>-<version>'
-    needle = f"{normalized}-{version}"
-    return needle in html
+
+    # Wheels escape the name with underscores (PEP 427); sdists use the
+    # raw project name. Accept either, then require the version to be
+    # followed by a wheel's '-' or an sdist's extension.
+    stem = re.escape(normalized).replace(r"\-", "[-_]")
+    pattern = re.compile(
+        rf"^{stem}-{re.escape(version)}(?:-[^/]*\.whl|\.tar\.gz|\.zip)$",
+        re.IGNORECASE,
+    )
+    urls: list[str] = []
+    for href in re.findall(r'href=[\'"]([^\'"]+)[\'"]', html):
+        # PEP 503 permits relative links; PyPI serves absolute ones to
+        # files.pythonhosted.org. Resolve against the index either way.
+        clean = urljoin(simple_url, href.split("#", 1)[0])
+        filename = unquote(clean.rsplit("/", 1)[-1])
+        if pattern.match(filename):
+            urls.append(clean)
+    return urls
+
+
+def is_fetchable(url: str, timeout: float = 10.0) -> bool:
+    """Whether ``url`` actually serves bytes right now.
+
+    Asks for a single byte. The simple index can list a release before
+    every CDN edge is serving the file, and pip downloads from a
+    different host than the index it resolved against — so "listed" and
+    "downloadable" are separate facts, and only the second one is the
+    condition a build actually needs.
+    """
+    _require_allowed_url(url, FILES_HOST, "pypi.org")
+    req = urllib.request.Request(url, headers={"Range": "bytes=0-0"})
+    with urllib.request.urlopen(req, timeout=timeout) as r:
+        return r.status in (200, 206)
+
+
+def is_version_available(package: str, version: str, timeout: float = 10.0) -> bool:
+    """Whether ``version`` is both listed *and* downloadable.
+
+    Listing alone is what this used to check, and it is not enough: a
+    green check followed immediately by a 404 inside a Docker build is
+    exactly the failure this guard exists to prevent.
+    """
+    urls = file_urls_for_version(package, version, timeout=timeout)
+    if not urls:
+        return False
+    return all(is_fetchable(u, timeout=timeout) for u in urls)
 
 
 def main(argv: list[str]) -> int:
@@ -95,7 +157,7 @@ def main(argv: list[str]) -> int:
         try:
             # Check the Simple API used by pip to avoid JSON/simple propagation skew
             if is_version_available(package, version):
-                print(f"Found {package} {version} on PyPI (simple index).")
+                print(f"Found {package} {version} on PyPI (listed and downloadable).")
                 return 0
         except (URLError, HTTPError, JSONDecodeError, socket.timeout) as exc:
             # Expected transient issues; log for CI visibility and retry.

--- a/tests/misc/test_wait_for_pypi_validation.py
+++ b/tests/misc/test_wait_for_pypi_validation.py
@@ -45,10 +45,10 @@ def test_fetch_json_allows_pypi_https_and_reads(monkeypatch):
         def __exit__(self, exc_type, exc, tb):
             return False
 
-    def fake_urlopen(url, timeout=10.0):  # noqa: ARG001 - match signature
+    def fake_urlopen(url, *hosts, timeout=10.0):  # noqa: ARG001 - match signature
         return FakeResponse()
 
-    monkeypatch.setattr(mod.urllib.request, "urlopen", fake_urlopen)
+    monkeypatch.setattr(mod, "_urlopen", fake_urlopen)
     data = mod.fetch_json("https://pypi.org/pypi/pkg/json")
     assert isinstance(data, dict)
     assert "releases" in data
@@ -104,14 +104,14 @@ def test_is_version_available_checks_simple_and_then_the_file(monkeypatch):
 
     seen: list[str] = []
 
-    def fake_urlopen(url, timeout=10.0):  # noqa: ARG001
+    def fake_urlopen(url, *hosts, timeout=10.0):  # noqa: ARG001
         target = url if isinstance(url, str) else url.full_url
         seen.append(target)
         if target.endswith("/simple/zyra/"):
             return Resp('<a href="/packages/x/zyra-1.2.3.tar.gz">zyra-1.2.3.tar.gz</a>')
         return Resp(status=206)
 
-    monkeypatch.setattr(mod.urllib.request, "urlopen", fake_urlopen)
+    monkeypatch.setattr(mod, "_urlopen", fake_urlopen)
     assert mod.is_version_available("Zyra", "1.2.3") is True
     # Both hops, not just the index.
     assert any(u.endswith("/simple/zyra/") for u in seen)
@@ -145,7 +145,7 @@ def _patch_index(mod, monkeypatch, html: str):
         def __exit__(self, *a):
             return False
 
-    monkeypatch.setattr(mod.urllib.request, "urlopen", lambda *a, **k: FakeResponse())
+    monkeypatch.setattr(mod, "_urlopen", lambda *a, **k: FakeResponse())
 
 
 def test_file_urls_match_the_exact_version_not_a_prefix(monkeypatch):
@@ -186,7 +186,7 @@ def test_listed_but_unfetchable_is_not_available(monkeypatch):
     def _404(*a, **k):
         raise urllib.error.HTTPError("u", 404, "Not Found", None, None)
 
-    monkeypatch.setattr(mod.urllib.request, "urlopen", _404)
+    monkeypatch.setattr(mod, "_urlopen", _404)
     with pytest.raises(urllib.error.HTTPError):
         mod.is_fetchable(
             "https://files.pythonhosted.org/packages/ab/cd/zyra-0.1.53.tar.gz"
@@ -212,3 +212,76 @@ def test_no_files_means_not_available(monkeypatch):
     mod = _load_wait_module()
     monkeypatch.setattr(mod, "file_urls_for_version", lambda *a, **k: [])
     assert mod.is_version_available("zyra", "0.1.53") is False
+
+
+# --- what counts as "the same host" ------------------------------------
+#
+# The guard compared `netloc`, which carries the port and any userinfo.
+# That is over-strict in one direction (a default port spelled out loud
+# is the same host) without being any safer in the other.
+
+
+def test_allowlist_accepts_an_explicit_default_port():
+    """`https://pypi.org:443/...` is pypi.org, not a stranger."""
+    mod = _load_wait_module()
+    mod._require_allowed_url("https://pypi.org:443/simple/zyra/", "pypi.org")
+
+
+def test_allowlist_is_case_insensitive_on_the_host():
+    """Hostnames are case-insensitive; the guard should be too."""
+    mod = _load_wait_module()
+    mod._require_allowed_url("https://PyPI.ORG/simple/zyra/", "pypi.org")
+    # ...including when the allowlist itself is the odd one out.
+    mod._require_allowed_url("https://pypi.org/simple/zyra/", "PyPI.org")
+
+
+def test_allowlist_is_not_fooled_by_userinfo():
+    """`https://pypi.org@evil.example/` is a request to evil.example."""
+    mod = _load_wait_module()
+    with pytest.raises(ValueError):
+        mod._require_allowed_url("https://pypi.org@evil.example/x.whl", "pypi.org")
+    with pytest.raises(ValueError):
+        mod._require_allowed_url("https://pypi.org:443@evil.example/x.whl", "pypi.org")
+
+
+# --- redirects ---------------------------------------------------------
+#
+# urllib follows redirects on its own. Validating only the URL we ask for
+# checks the one hop that was never in doubt, and checking geturl() after
+# the fact is too late: the request has already been issued. These pin
+# the check at the point where it can still refuse.
+
+
+def _redirect(mod, hosts, newurl):
+    import urllib.request
+
+    handler = mod._AllowlistRedirectHandler(hosts)
+    req = urllib.request.Request("https://pypi.org/simple/zyra/")
+    return handler.redirect_request(req, None, 302, "Found", {}, newurl)
+
+
+def test_redirect_off_the_allowlist_is_refused_before_it_is_followed():
+    mod = _load_wait_module()
+    with pytest.raises(ValueError):
+        _redirect(mod, ("pypi.org", mod.FILES_HOST), "https://evil.example/x.whl")
+
+
+def test_redirect_within_the_allowlist_is_followed():
+    """The index legitimately redirects to the files host — don't break that."""
+    mod = _load_wait_module()
+    out = _redirect(
+        mod,
+        ("pypi.org", mod.FILES_HOST),
+        f"https://{mod.FILES_HOST}/packages/ab/cd/zyra-0.1.53.tar.gz",
+    )
+    assert out is not None
+    assert out.full_url.startswith(f"https://{mod.FILES_HOST}/")
+
+
+def test_downgrade_to_http_on_redirect_is_refused():
+    """A redirect is also a way to drop out of TLS."""
+    mod = _load_wait_module()
+    with pytest.raises(ValueError):
+        _redirect(
+            mod, ("pypi.org", mod.FILES_HOST), f"http://{mod.FILES_HOST}/x.tar.gz"
+        )

--- a/tests/misc/test_wait_for_pypi_validation.py
+++ b/tests/misc/test_wait_for_pypi_validation.py
@@ -79,13 +79,19 @@ def test_main_bubbles_unexpected_errors(monkeypatch):
         mod.main(["wait_for_pypi.py", "zyra", "9.9.9", "1", "0"])
 
 
-def test_is_version_available_checks_simple(monkeypatch):
-    """is_version_available should check the PyPI simple index for the version."""
+def test_is_version_available_checks_simple_and_then_the_file(monkeypatch):
+    """Availability now means listed *and* downloadable.
+
+    It used to mean listed only, which let the guard pass while the
+    file was still 404ing from the CDN pip fetches it from. The fake
+    below has to answer both hops for this to return True.
+    """
     mod = _load_wait_module()
 
     class Resp:
-        def __init__(self, text: str):
+        def __init__(self, text: str = "", status: int = 200):
             self._b = text.encode("utf-8")
+            self.status = status
 
         def __enter__(self):
             return self
@@ -96,10 +102,113 @@ def test_is_version_available_checks_simple(monkeypatch):
         def read(self):
             return self._b
 
+    seen: list[str] = []
+
     def fake_urlopen(url, timeout=10.0):  # noqa: ARG001
-        assert url.endswith("/simple/zyra/")
-        # Include the normalized filename pattern with version
-        return Resp('<a href="/packages/.../zyra-1.2.3.tar.gz">zyra-1.2.3.tar.gz</a>')
+        target = url if isinstance(url, str) else url.full_url
+        seen.append(target)
+        if target.endswith("/simple/zyra/"):
+            return Resp('<a href="/packages/x/zyra-1.2.3.tar.gz">zyra-1.2.3.tar.gz</a>')
+        return Resp(status=206)
 
     monkeypatch.setattr(mod.urllib.request, "urlopen", fake_urlopen)
     assert mod.is_version_available("Zyra", "1.2.3") is True
+    # Both hops, not just the index.
+    assert any(u.endswith("/simple/zyra/") for u in seen)
+    assert any("zyra-1.2.3.tar.gz" in u for u in seen)
+
+
+# --- file-level availability -------------------------------------------
+#
+# The old check asked the simple index whether the version was *listed*.
+# pip downloads from files.pythonhosted.org, a different host behind a
+# different CDN, so "listed" and "downloadable" propagate independently:
+# the guard went green and the very next `pip install` 404'd inside the
+# Docker build. These cover the gap that closes.
+
+
+def _index_html(*filenames: str) -> str:
+    links = "".join(
+        f'<a href="https://files.pythonhosted.org/packages/ab/cd/{f}#sha256=x">{f}</a>'
+        for f in filenames
+    )
+    return f"<html><body>{links}</body></html>"
+
+
+def _patch_index(mod, monkeypatch, html: str):
+    class FakeResponse:
+        def __enter__(self):
+            import io
+
+            return io.BytesIO(html.encode())
+
+        def __exit__(self, *a):
+            return False
+
+    monkeypatch.setattr(mod.urllib.request, "urlopen", lambda *a, **k: FakeResponse())
+
+
+def test_file_urls_match_the_exact_version_not_a_prefix(monkeypatch):
+    """`0.1.53` must not be satisfied by `0.1.53.1`.
+
+    The previous substring check accepted it, so a *different* release
+    could end the wait.
+    """
+    mod = _load_wait_module()
+    _patch_index(mod, monkeypatch, _index_html("zyra-0.1.53.1.tar.gz"))
+    assert mod.file_urls_for_version("zyra", "0.1.53") == []
+
+
+def test_file_urls_find_wheel_and_sdist(monkeypatch):
+    mod = _load_wait_module()
+    _patch_index(
+        mod,
+        monkeypatch,
+        _index_html("zyra-0.1.53-py3-none-any.whl", "zyra-0.1.53.tar.gz"),
+    )
+    urls = mod.file_urls_for_version("zyra", "0.1.53")
+    assert len(urls) == 2
+    # The fragment is stripped so the URL can be fetched directly.
+    assert all("#" not in u for u in urls)
+
+
+def test_listed_but_unfetchable_is_not_available(monkeypatch):
+    """The exact race: the index lists it, the CDN does not serve it yet."""
+    mod = _load_wait_module()
+    monkeypatch.setattr(
+        mod,
+        "file_urls_for_version",
+        lambda *a, **k: [
+            "https://files.pythonhosted.org/packages/ab/cd/zyra-0.1.53.tar.gz"
+        ],
+    )
+
+    def _404(*a, **k):
+        raise urllib.error.HTTPError("u", 404, "Not Found", None, None)
+
+    monkeypatch.setattr(mod.urllib.request, "urlopen", _404)
+    with pytest.raises(urllib.error.HTTPError):
+        mod.is_fetchable(
+            "https://files.pythonhosted.org/packages/ab/cd/zyra-0.1.53.tar.gz"
+        )
+
+
+def test_is_fetchable_allows_the_files_host_but_not_others():
+    """The file check has to follow the index's links off pypi.org."""
+    mod = _load_wait_module()
+    mod._require_allowed_url(
+        "https://files.pythonhosted.org/packages/ab/cd/zyra-0.1.53.tar.gz",
+        "files.pythonhosted.org",
+    )
+    with pytest.raises(ValueError):
+        mod._require_allowed_url("https://evil.example/x.whl", "files.pythonhosted.org")
+    with pytest.raises(ValueError):
+        mod._require_allowed_url(
+            "http://files.pythonhosted.org/x.whl", "files.pythonhosted.org"
+        )
+
+
+def test_no_files_means_not_available(monkeypatch):
+    mod = _load_wait_module()
+    monkeypatch.setattr(mod, "file_urls_for_version", lambda *a, **k: [])
+    assert mod.is_version_available("zyra", "0.1.53") is False


### PR DESCRIPTION
## Summary

The image build during a release intermittently fails with pip unable to find the version that was just published, and a rerun fixes it. `wait_for_pypi.py` is supposed to prevent exactly that, and it *does* run — so the interesting question was why it passes and the install still 404s.

```
ERROR: process "/bin/bash -o pipefail -c ... pip install --no-cache-dir --no-compile
  \"zyra[${ZYRA_EXTRAS}]==${ZYRA_VERSION}\" ..." did not complete successfully: exit code: 1
```

**It checks the wrong hop.** The script polls `https://pypi.org/simple/NAME/` for the version. pip *resolves* against that index but *downloads* from `files.pythonhosted.org` — a different host behind a different CDN, propagating independently. The index can list a release before every edge is serving the file, so the guard goes green, buildx starts, and the download 404s.

Two things widen the window:

- The wait runs on the **runner**; `pip install` runs inside **BuildKit**. They need not share a CDN edge, so a fresh view on the runner does not imply a fresh view in the build container.
- The `zyra` image builds **arm64 under QEMU**, so that leg starts later and takes considerably longer than amd64 — more time to land on a stale edge.

That matches the observed behaviour exactly: nothing wrong with the release, the check is just satisfiable slightly before the download is.

## Related Issue

No issue filed; surfaced while rolling v0.1.53. Unrelated to the data-encoded work in #290/#291 — this only touches the release tooling.

## Issue Type
- [x] Bug
- [ ] Feature
- [ ] Workflow Gap
- [ ] Task

## Changes

**Verify the file is fetchable, not merely listed.** Parse the index's own links, then issue a ranged GET (`Range: bytes=0-0`) against each until it serves bytes. Same retry loop, one extra hop.

The SSRF guard gains `files.pythonhosted.org` — following those links is the entire point — and is factored into a single `_require_allowed_url` helper so both hops are checked identically rather than by two copies of the same three lines.

**Two related fixes while here**, both found by writing the tests:

- The match was the substring `NAME-VERSION`, which `0.1.53.1` also satisfies when waiting for `0.1.53`. A *different* release could end the wait. It is now anchored on the whole filename, accepting either a wheel's escaped name or an sdist's extension.
- Relative `href`s were rejected outright by the host guard. PEP 503 permits them; PyPI happens to serve absolute ones, so this never bit, but the assumption was unnecessary. They now resolve against the index URL.

## Type of Change
- [x] Bug fix
- [ ] Feature
- [ ] Workflow Gap implementation
- [ ] 🧹 Task (maintenance/refactor/CI/docs)
- [ ] Docs only / CI only
- [ ] Refactor (no functional change)

## Impact / Risk

Release tooling only — no runtime code, no schema, no CLI surface.

`is_version_available` now means **listed and downloadable** where it used to mean listed. That is the point of the change, but it does alter an existing contract, so its existing test was updated to answer both hops rather than only the index. Flagging that explicitly rather than burying it: a changed assertion in a pre-existing test deserves a reviewer's eye.

The check is strictly more conservative, so the worst case is waiting longer, bounded by the same `retries × delay` (default 60 × 10s). It cannot pass in a case where the old one failed.

**This narrows the window rather than closing it.** The runner's CDN edge still is not BuildKit's, so a sufficiently unlucky build could still race. The belt-and-braces companion would be a pip retry inside `docker/zyra/Dockerfile` and `docker/zyra-scheduler/Dockerfile`; I have deliberately left that out to keep this change to one idea, and it is easy to add if this proves insufficient.

## Validation Steps

Against live PyPI:

```bash
poetry run python scripts/wait_for_pypi.py zyra 0.1.53 3 2
# Waiting for zyra 0.1.53 to appear on PyPI...
# Found zyra 0.1.53 on PyPI (listed and downloadable).   exit 0
```

`0.1.53` resolves to both the wheel and the sdist on `files.pythonhosted.org`, and both serve bytes; `0.1.99` resolves to nothing and correctly reports unavailable.

```bash
poetry run pytest tests/misc/ -q     # 43 passed, 8 skipped
```

New tests cover: the exact-version match rejecting `0.1.53.1`; wheel and sdist both found with the fragment stripped; the listed-but-unfetchable race itself; the host guard allowing `files.pythonhosted.org` while still rejecting other hosts and plain HTTP; and the empty-file-list case.

`ruff check` and `ruff format --check` are clean on both files. (`scripts/wait_for_pypi.py` reports one `UP041` on an untouched `except` clause — present identically before this change, and an artifact of a newer local ruff than the pinned `^0.6.4`.)

## Checklist

- [x] Code follows project style guidelines
- [x] All tests pass locally
- [x] Documentation builds cleanly from docstrings
- [ ] I have linked this PR to a relevant issue — none exists; context is in the summary
- [x] No secrets or credentials added; follows repo guardrails
- [x] All commits in this PR are Signed-off-by (DCO)