### PR TITLE
Document the all-files PyPI contract, and test it through the aggregate

### DIFF
--- a/scripts/wait_for_pypi.py
+++ b/scripts/wait_for_pypi.py
@@ -150,11 +150,25 @@ def is_fetchable(url: str, timeout: float = 10.0) -> bool:
 
 
 def is_version_available(package: str, version: str, timeout: float = 10.0) -> bool:
-    """Whether ``version`` is both listed *and* downloadable.
+    """Whether ``version`` is listed *and* every listed file is downloadable.
 
     Listing alone is what this used to check, and it is not enough: a
     green check followed immediately by a 404 inside a Docker build is
     exactly the failure this guard exists to prevent.
+
+    **Every** file, not the first one that answers. Requiring only one
+    would pick the wrong file as often as not: pip installs the wheel
+    normally, but a source build — a ``--no-binary`` install, or a
+    platform with no matching wheel — reaches for the sdist, so a green
+    check on whichever happened to respond first says nothing about the
+    file pip will actually download. All of them serving is also better
+    evidence of the thing actually being waited on, which is that the
+    release has propagated to the edge serving this build.
+
+    The two ways of being wrong are not symmetric. Waiting too long is
+    bounded by ``retries × delay`` and merely delays a release; going
+    green too early fails the image build, which is the bug this exists
+    to fix.
     """
     urls = file_urls_for_version(package, version, timeout=timeout)
     if not urls:

--- a/src/zyra/visualization/cli_utils.py
+++ b/src/zyra/visualization/cli_utils.py
@@ -18,15 +18,25 @@ def load_geotiff_array(input_path: str, *, band: int = 1, south_up: bool = True)
     NaN renders transparent in the raster visualizers, so warp fill and
     masked regions disappear instead of plotting as a solid value.
 
-    The returned array is **south-up** — row 0 is the southernmost row.
-    That is the convention every raster visualizer here already assumes:
-    ``heatmap`` draws with ``origin="lower"`` and ``contour`` builds its
-    y coordinates as ``linspace(south, north)``. GeoTIFFs are
+    Orientation of the returned array depends on ``south_up``, and the
+    two consumers want opposite things.
+
+    By default it is **south-up** — row 0 is the southernmost row. That
+    is the convention every *figure* visualizer here assumes: ``heatmap``
+    draws with ``origin="lower"`` and ``contour`` builds its y
+    coordinates as ``linspace(south, north)``. GeoTIFFs are
     conventionally north-up instead, so returning one as read renders it
     mirrored about the equator (see #281 — the global smoke frames put
     northern-hemisphere plumes over the Southern Ocean). The flip is
     keyed off the transform rather than assumed, so a genuinely south-up
-    GeoTIFF is left alone.
+    GeoTIFF is left alone either way.
+
+    With ``south_up=False`` the file's own row order is preserved, so a
+    conventional north-up GeoTIFF comes back north-up. That is what the
+    data-encoded writer needs: ``write_luma_png`` hands the array
+    straight to PIL and a PNG's first row is its **top**, with no
+    ``origin="lower"`` anywhere to undo a flip. Taking the default there
+    reproduced #281 on the one path it could not have covered.
 
     Parameters
     ----------
@@ -34,6 +44,12 @@ def load_geotiff_array(input_path: str, *, band: int = 1, south_up: bool = True)
         Path to a ``.tif``/``.tiff`` file.
     band : int, default 1
         1-based band index to read.
+    south_up : bool, default True
+        Whether to return the array south-up (row 0 southernmost),
+        flipping a north-up GeoTIFF to match. Pass ``False`` to keep the
+        file's own row order — needed when the array is written straight
+        to an image rather than drawn with ``origin="lower"``. The
+        default preserves the figure path's behaviour exactly.
 
     Raises
     ------

--- a/tests/misc/test_wait_for_pypi_validation.py
+++ b/tests/misc/test_wait_for_pypi_validation.py
@@ -172,8 +172,20 @@ def test_file_urls_find_wheel_and_sdist(monkeypatch):
     assert all("#" not in u for u in urls)
 
 
-def test_listed_but_unfetchable_is_not_available(monkeypatch):
-    """The exact race: the index lists it, the CDN does not serve it yet."""
+def test_listed_but_unfetchable_never_ends_the_wait(monkeypatch):
+    """The exact race: the index lists it, the CDN does not serve it yet.
+
+    Driven through ``is_version_available`` and ``main``, not
+    ``is_fetchable``. An earlier version of this test called the leaf
+    directly while patching ``file_urls_for_version`` — setup for a call
+    it never made — so it asserted nothing about the aggregate that the
+    release job actually invokes, which is the only thing that decides
+    whether a build starts.
+
+    A 404 propagates rather than resolving to False: ``main`` classes it
+    as transient and retries, which is what should happen while a CDN
+    catches up. What must never happen is the wait ending green.
+    """
     mod = _load_wait_module()
     monkeypatch.setattr(
         mod,
@@ -188,9 +200,32 @@ def test_listed_but_unfetchable_is_not_available(monkeypatch):
 
     monkeypatch.setattr(mod, "_urlopen", _404)
     with pytest.raises(urllib.error.HTTPError):
-        mod.is_fetchable(
-            "https://files.pythonhosted.org/packages/ab/cd/zyra-0.1.53.tar.gz"
-        )
+        mod.is_version_available("zyra", "0.1.53")
+
+    # End to end: retried, then gave up. Never exit 0.
+    assert mod.main(["wait_for_pypi.py", "zyra", "0.1.53", "2", "0"]) == 1
+
+
+def test_every_listed_file_must_be_fetchable(monkeypatch):
+    """One file answering is not enough to end the wait.
+
+    pip installs the wheel normally, but a source build reaches for the
+    sdist, so going green on whichever responded first says nothing
+    about the file pip will actually download. This pins the `all`, not
+    `any`, that `is_version_available` is built on.
+    """
+    mod = _load_wait_module()
+    wheel = "https://files.pythonhosted.org/packages/ab/cd/zyra-0.1.53-py3-none-any.whl"
+    sdist = "https://files.pythonhosted.org/packages/ab/cd/zyra-0.1.53.tar.gz"
+    monkeypatch.setattr(mod, "file_urls_for_version", lambda *a, **k: [wheel, sdist])
+
+    # Wheel up, sdist still propagating — not available.
+    monkeypatch.setattr(mod, "is_fetchable", lambda u, **k: u == wheel)
+    assert mod.is_version_available("zyra", "0.1.53") is False
+
+    # Only both serving is green.
+    monkeypatch.setattr(mod, "is_fetchable", lambda u, **k: True)
+    assert mod.is_version_available("zyra", "0.1.53") is True
 
 
 def test_is_fetchable_allows_the_files_host_but_not_others():


### PR DESCRIPTION
## Summary

Three review comments on the 0.1.54 staging → main PR, all valid. Two are documentation, one is a test that did not test what its name claimed. **No executable line changes in either source file.**

Branched from `mirror/staging` at `3e2b7ef0` (0.1.54, with #356/#357 in it) so it relays cleanly and can be tacked onto the open release PR.

## Related Issue

Review follow-up to [NOAA-GSL#356](https://github.com/NOAA-GSL/zyra/pull/356) and [NOAA-GSL#357](https://github.com/NOAA-GSL/zyra/pull/357), both merged into `staging`. No issue filed.

## Issue Type
- [x] Bug
- [ ] Feature
- [ ] Workflow Gap
- [ ] Task

## Changes

### 1. The `all()` vs `any()` disagreement — prose was wrong, code was right

`is_version_available` requires **every** listed file to be fetchable. The PR description said the check issues a ranged GET against each link "until one serves bytes", which describes `any()`. The reviewer correctly flagged that the two disagree and asked for one to move.

The code is the correct side, so the prose moved. Requiring only one file would pick the wrong file as often as not: pip installs the wheel normally, but a source build — a `--no-binary` install, or a platform with no matching wheel — reaches for the sdist. A green check on whichever link happened to respond first says nothing about the file pip will actually download. All of them serving is also better evidence of the thing genuinely being waited on, which is that the release has propagated to *this* edge.

The two ways of being wrong are not symmetric, which settles it:

| | cost |
|---|---|
| waiting too long | bounded by `retries × delay`, delays a release |
| going green too early | fails the image build — **the bug this exists to fix** |

The docstring now states the contract and the reasoning, and a new test pins `all` rather than `any` so it cannot quietly drift back.

### 2. A test that asserted the wrong function

`test_listed_but_unfetchable_is_not_available` called `is_fetchable` directly while patching `file_urls_for_version` — setup for a call it never made, which is the tell. It asserted nothing about `is_version_available`, which is what the release job invokes and the only thing that decides whether a build starts.

Now driven through `is_version_available` **and** `main`. The 404 propagates rather than resolving to `False` — `main` classes it as transient and retries, which is what should happen while a CDN catches up — and the run ends exit 1. Renamed to `test_listed_but_unfetchable_never_ends_the_wait`, which is what it checks.

### 3. `load_geotiff_array` docstring omitted `south_up`

The parameter arrived in #357 but the docstring still read as though the result were always south-up, and `Parameters` did not list it. It now describes both orientations, why the figure path and the data-encoded writer want opposite things, and documents the flag. The `load_data_array` wrapper already documented its own `geotiff_south_up`.

## Type of Change
- [x] Bug fix
- [ ] Feature
- [ ] Workflow Gap implementation
- [ ] 🧹 Task (maintenance/refactor/CI/docs)
- [ ] Docs only / CI only
- [ ] Refactor (no functional change)

## Impact / Risk

**Behaviourally inert.** Both source files change docstrings only — confirmed by filtering the diff for non-comment, non-docstring lines, which comes back empty. `is_version_available` keeps the semantics it shipped with in #356; nothing about the wait, the release job, or the GeoTIFF loader behaves differently.

The one thing a reviewer should weigh is whether `all()` is the right contract at all, since this PR pins it rather than changing it. The argument is above; the counter-argument is that it waits on files pip may never fetch, at the cost of a bounded delay. If you'd rather have `any()`, this is the moment to say so — the test now makes either choice explicit instead of incidental.

## Validation Steps

```bash
poetry run pytest tests/misc/test_wait_for_pypi_validation.py -q   # 18 passed
```

New/changed tests:

- `test_listed_but_unfetchable_never_ends_the_wait` — 404 propagates out of `is_version_available`, and `main` retries then exits 1.
- `test_every_listed_file_must_be_fetchable` — wheel up + sdist still propagating is **not** available; only both serving is green.

Lint verified with the **pinned** ruff 0.6.9, not the newer local build — the mismatch that caused a CI failure on #357:

```
ruff 0.6.9
format --check .   → 383 files already formatted
check <3 files>    → All checks passed!
```

`tests/visualization/` could not be run in this environment (no numpy/rasterio installed here); the change to `cli_utils.py` is a docstring, and CI covers it.

## Checklist

- [x] Code follows project style guidelines
- [x] All tests pass locally — see the environment note above
- [x] Documentation builds cleanly from docstrings
- [ ] I have linked this PR to a relevant issue — none exists; context above
- [x] No secrets or credentials added; follows repo guardrails
- [x] All commits in this PR are Signed-off-by (DCO)

---
_Generated by [Claude Code](https://claude.ai/code/session_0191uuM3tfyBtDCMvZ2yJCtz)_