### PR TITLE
Retry the zyra install inside the build, where BuildKit's CDN edge is

### DIFF
--- a/docker/zyra-scheduler/Dockerfile
+++ b/docker/zyra-scheduler/Dockerfile
@@ -80,17 +80,38 @@ RUN --mount=type=bind,from=wgrib2-builder,source=/out,target=/tmp/wgrib2,ro \
 # Install Zyra from PyPI, pin to release if provided
 ARG ZYRA_VERSION
 ARG ZYRA_EXTRAS
-RUN if [ -z "$ZYRA_VERSION" ] || [ "$ZYRA_VERSION" = "latest" ]; then \
+RUN set -e; \
+    # Retry just the zyra install while a fresh release propagates.
+    # See docker/zyra/Dockerfile for the full reasoning: the release
+    # job's wait_for_pypi.py check runs on the GitHub runner, this
+    # install runs inside BuildKit, and the two do not share a PyPI CDN
+    # edge — so a build can 404 on a version the guard just confirmed.
+    # pip's --retries does not cover it ("no matching distribution" is a
+    # successful fetch of an index missing the version, not a transport
+    # error), and the retry has to happen where the install happens.
+    zyra_pip() { \
+      local attempt=1; \
+      until pip install --no-cache-dir --no-compile "$@"; do \
+        if [ "$attempt" -ge 10 ]; then \
+          echo "zyra install still failing after $attempt attempts; giving up" >&2; \
+          return 1; \
+        fi; \
+        echo "zyra install failed (attempt $attempt/10) - index may not have reached this edge yet; retrying in 30s" >&2; \
+        sleep 30; \
+        attempt=$((attempt + 1)); \
+      done; \
+    }; \
+    if [ -z "$ZYRA_VERSION" ] || [ "$ZYRA_VERSION" = "latest" ]; then \
       if [ -n "$ZYRA_EXTRAS" ]; then \
-        pip install --no-cache-dir --no-compile "zyra[${ZYRA_EXTRAS}]"; \
+        zyra_pip "zyra[${ZYRA_EXTRAS}]"; \
       else \
-        pip install --no-cache-dir --no-compile zyra; \
+        zyra_pip zyra; \
       fi; \
     else \
       if [ -n "$ZYRA_EXTRAS" ]; then \
-        pip install --no-cache-dir --no-compile "zyra[${ZYRA_EXTRAS}]==${ZYRA_VERSION}"; \
+        zyra_pip "zyra[${ZYRA_EXTRAS}]==${ZYRA_VERSION}"; \
       else \
-        pip install --no-cache-dir --no-compile "zyra==${ZYRA_VERSION}"; \
+        zyra_pip "zyra==${ZYRA_VERSION}"; \
       fi; \
     fi \
     && pip install --no-cache-dir --upgrade 'setuptools>=78.1.1' 'wheel>=0.46.2'

--- a/docker/zyra/Dockerfile
+++ b/docker/zyra/Dockerfile
@@ -97,6 +97,38 @@ ARG ZYRA_VERSION
 ARG ZYRA_EXTRAS
 ARG ZYRA_EXTRAS_ARM64
 RUN set -eux; \
+    # Retry just the zyra install while a fresh release propagates.
+    #
+    # The release job runs scripts/wait_for_pypi.py before this build and
+    # will not start it until the version is listed and its files serve
+    # bytes. That check runs on the GitHub runner; this install runs
+    # inside BuildKit, and the two do not share a PyPI CDN edge. A build
+    # has already failed with "Could not find a version that satisfies
+    # the requirement zyra==0.1.54" minutes after that guard printed
+    # "listed and downloadable" — the runner's edge had the release and
+    # BuildKit's did not. No amount of checking from the runner can fix
+    # that; the retry has to happen where the install happens.
+    #
+    # pip's own --retries does not cover it. "No matching distribution"
+    # is a *successful* fetch of an index that does not list the version
+    # yet, not a transport error, so pip has nothing to retry. The only
+    # thing that helps is asking again later.
+    #
+    # Scoped to zyra deliberately: every other dependency here has been
+    # on PyPI for a long time, and wrapping those would turn a genuine
+    # resolution conflict into a five-minute wait before the same error.
+    zyra_pip() { \
+      local attempt=1; \
+      until pip install --no-cache-dir --no-compile "$@"; do \
+        if [ "$attempt" -ge 10 ]; then \
+          echo "zyra install still failing after $attempt attempts; giving up" >&2; \
+          return 1; \
+        fi; \
+        echo "zyra install failed (attempt $attempt/10) - index may not have reached this edge yet; retrying in 30s" >&2; \
+        sleep 30; \
+        attempt=$((attempt + 1)); \
+      done; \
+    }; \
     EXTRAS="$ZYRA_EXTRAS"; \
     if [ "${TARGETARCH}" = "arm64" ]; then \
       if [ -n "${ZYRA_EXTRAS_ARM64}" ]; then \
@@ -105,9 +137,9 @@ RUN set -eux; \
       else \
         echo "ARM64: installing zyra without pygrib (use cfgrib/wgrib2)"; \
         if [ -z "$ZYRA_VERSION" ] || [ "$ZYRA_VERSION" = "latest" ]; then \
-          pip install --no-cache-dir --no-compile zyra; \
+          zyra_pip zyra; \
         else \
-          pip install --no-cache-dir --no-compile "zyra==${ZYRA_VERSION}"; \
+          zyra_pip "zyra==${ZYRA_VERSION}"; \
         fi; \
         # Manually install processing/visualization/connectors deps excluding pygrib
         pip install --no-cache-dir --no-compile \
@@ -121,15 +153,15 @@ RUN set -eux; \
     fi; \
     if [ -z "$ZYRA_VERSION" ] || [ "$ZYRA_VERSION" = "latest" ]; then \
       if [ -n "$EXTRAS" ]; then \
-        pip install --no-cache-dir --no-compile "zyra[${EXTRAS}]"; \
+        zyra_pip "zyra[${EXTRAS}]"; \
       else \
-        pip install --no-cache-dir --no-compile zyra; \
+        zyra_pip zyra; \
       fi; \
     else \
       if [ -n "$EXTRAS" ]; then \
-        pip install --no-cache-dir --no-compile "zyra[${EXTRAS}]==${ZYRA_VERSION}"; \
+        zyra_pip "zyra[${EXTRAS}]==${ZYRA_VERSION}"; \
       else \
-        pip install --no-cache-dir --no-compile "zyra==${ZYRA_VERSION}"; \
+        zyra_pip "zyra==${ZYRA_VERSION}"; \
       fi; \
     fi \
     && pip install --no-cache-dir --upgrade 'setuptools>=78.1.1' 'wheel>=0.46.2'


### PR DESCRIPTION
## Summary

The 0.1.54 image build failed with:

```
ERROR: Could not find a version that satisfies the requirement zyra==0.1.54
       (from versions: 0.1.22, ... 0.1.52, 0.1.53)
ERROR: No matching distribution found for zyra==0.1.54
```

…minutes after the release job's own guard, in the same workflow run, printed:

```
Waiting for zyra 0.1.54 to appear on PyPI...
Found zyra 0.1.54 on PyPI (listed and downloadable).
```

**Both are true.** `scripts/wait_for_pypi.py` runs on the GitHub runner; `pip install` runs inside **BuildKit**, and the two do not share a PyPI CDN edge. The runner's edge had 0.1.54 listed with both files serving bytes. BuildKit's simple index still ended at 0.1.53.

I caught the same skew from a third vantage point while diagnosing: PyPI's **JSON API** reported `latest: 0.1.54` while the **simple index** fetched seconds later did not list 0.1.54 at all. It propagated a few minutes later.

## Related Issue

The residual window explicitly named in [NOAA-GSL#356](https://github.com/NOAA-GSL/zyra/pull/356), which added the file-fetchability check:

> **This narrows the window rather than closing it.** The runner's CDN edge still is not BuildKit's, so a sufficiently unlucky build could still race. The belt-and-braces companion would be a pip retry inside `docker/zyra/Dockerfile` and `docker/zyra-scheduler/Dockerfile`; I have deliberately left that out to keep this change to one idea, and it is easy to add if this proves insufficient.

It has proven insufficient. "One idea per PR" was the right call then and is the wrong one now.

## Issue Type
- [x] Bug
- [ ] Feature
- [ ] Workflow Gap
- [ ] Task

## Changes

A bounded retry around the **zyra install only**, in both Dockerfiles.

**Why the retry has to be here and not on the runner.** No check performed on the runner can close this window, because the runner is not the host that resolves the install. `wait_for_pypi.py` is still worth keeping — it fails fast and cheaply when a release genuinely has not been published — but it can only ever be evidence about its own edge.

**Why `pip install --retries` does not help.** That flag covers transport errors. `No matching distribution` is a *successful* fetch of an index that does not list the version yet, so pip has nothing to retry. It has to be asked again later, which means re-invoking it.

`zyra_pip` retries up to 10 times at 30s — roughly 4.5 minutes of tolerance, comfortably more than the observed skew.

**Scoped deliberately.** 6 call sites in `docker/zyra/Dockerfile` (both arch branches × pinned/unpinned × with/without extras) and 4 in `docker/zyra-scheduler/Dockerfile`. Every other dependency in these images has been on PyPI for years; wrapping those would turn a genuine resolution conflict into a five-minute wait before the identical error.

## Type of Change
- [x] Bug fix
- [ ] Feature
- [ ] Workflow Gap implementation
- [ ] 🧹 Task (maintenance/refactor/CI/docs)
- [ ] Docs only / CI only
- [ ] Refactor (no functional change)

## Impact / Risk

**The failure mode that would matter is a swallowed error**, so that is what I tested hardest. `set -e` semantics around shell functions and `&&` lists are exactly where reasoning goes wrong, so I simulated each path instead of arguing about it:

| path | expected | result |
|---|---|---|
| transient failure, then success | retries, proceeds | ✅ returns 0 on attempt 3 |
| permanent failure | build fails | ✅ gives up after 10, RUN exits 1 |
| **arm64 branch** (body ends in an explicit `exit 0`) | build fails | ✅ exits 1, never reaches `exit 0` |

The arm64 case is the one worth a reviewer's attention: a swallowed failure there would produce a **green build with zyra absent**, which is worse than the bug being fixed.

I also checked the *pre-existing* structure the same way to be sure I was not inheriting a latent version of that bug — it is sound, and this introduces no regression in it. (An earlier iteration of my own test harness appeared to show the opposite; that was an artifact of the harness appending a trailing command the real Dockerfile does not have, which masked the exit status.)

Worst case if PyPI propagation ever exceeds the budget: the build fails after ~4.5 extra minutes with the same error it fails with today.

## Validation Steps

Both Dockerfiles rendered the way Docker renders them — whole-line comments stripped, then continuations joined with nothing (a backslash-newline removes both characters) — and syntax-checked:

```
docker/zyra/Dockerfile:           bash -n -> OK   (6 zyra_pip call sites)
docker/zyra-scheduler/Dockerfile: bash -n -> OK   (4 zyra_pip call sites)
```

The three control-flow simulations above were run as standalone scripts with `pip` and `sleep` stubbed, mirroring the real if/else structure including the `fi \` + `&& pip install …` tail.

Not built end-to-end here — this environment has no Docker daemon, and the race it fixes cannot be reproduced on demand anyway.

## Reviewer notes

- An alternative that would close the race outright rather than tolerate it: have the release job download the wheel it already verified and `COPY` it into the build, removing BuildKit's index dependency entirely. Larger change, and only the `zyra` wheel would need it. Worth considering if this still proves insufficient.
- 10 × 30s is a judgement call, not a measurement. Easy to raise.

## Checklist

- [x] Code follows project style guidelines
- [x] All tests pass locally — no test suite covers the Dockerfiles; see the simulations above
- [x] Documentation builds cleanly from docstrings
- [ ] I have linked this PR to a relevant issue — none exists; context above
- [x] No secrets or credentials added; follows repo guardrails
- [x] All commits in this PR are Signed-off-by (DCO)

---
_Generated by [Claude Code](https://claude.ai/code/session_0191uuM3tfyBtDCMvZ2yJCtz)_