### PR TITLE
Publish a JSON Schema for `zyra run` configs, with regeneration and drift checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,6 +34,15 @@ repos:
         files: ^src/zyra/(cli\.py|wizard/manifest\.py|api/services/manifest\.py|visualization/cli_register\.py|processing/__init__\.py|transform/__init__\.py|connectors/(ingest|egress|discovery)/__init__\.py)$
   - repo: local
     hooks:
+      - id: zyra-generate-pipeline-schema
+        name: Regenerate zyra run JSON Schema
+        entry: poetry run python scripts/generate_pipeline_schema.py
+        language: system
+        pass_filenames: false
+        stages: [commit]
+        files: ^(src/zyra/(pipeline_schema\.py|pipeline_runner\.py|wizard/zyra_capabilities/.+\.json)|scripts/generate_pipeline_schema\.py)$
+  - repo: local
+    hooks:
       - id: zyra-update-openapi-snapshots
         name: Update OpenAPI snapshot (paths + SHA256)
         entry: bash scripts/update_openapi_snapshot.sh

--- a/scripts/generate_pipeline_docs.py
+++ b/scripts/generate_pipeline_docs.py
@@ -1,0 +1,275 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Generate the wiki's per-command args reference from the capabilities manifest.
+
+Writes one page per stage plus an index, ready to paste into the wiki:
+
+    CLI-Args-Reference.md
+    Args-Acquire.md, Args-Process.md, ... (one per stage)
+
+Companion to ``scripts/generate_pipeline_schema.py``; both read the same
+committed manifest under ``zyra/wizard/zyra_capabilities/``, so the reference
+and the schema cannot disagree about which commands exist.
+
+Usage::
+
+    poetry run python scripts/generate_pipeline_docs.py --out-dir ./wiki
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "src"))
+
+from zyra.core.capabilities_loader import load_capabilities  # noqa: E402
+from zyra.pipeline_schema import (  # noqa: E402
+    STAGE_ALIASES,
+    STAGE_POSITIONALS,
+    capabilities_dir,
+)
+from zyra.stage_utils import normalize_stage_name  # noqa: E402
+
+STAGE_ORDER = [
+    "acquire",
+    "process",
+    "simulate",
+    "decide",
+    "visualize",
+    "narrate",
+    "verify",
+    "decimate",
+]
+STAGE_BLURB = {
+    "acquire": "Fetch bytes from a remote or local source into the pipeline.",
+    "process": "Decode, subset, convert, reproject, or enrich data and metadata.",
+    "simulate": "Generate synthetic or sampled data.",
+    "decide": "Choose parameters or optimize a plan.",
+    "visualize": "Render frames, plots, animations, or composed video.",
+    "narrate": "Generate text/narrative products.",
+    "verify": "Evaluate outputs against expectations.",
+    "decimate": "Write results out to local disk, FTP, S3, HTTP POST, or Vimeo.",
+}
+SKIP_FLAGS = {"--help"}
+
+
+def commands_by_stage() -> dict[str, dict[str, dict[str, Any]]]:
+    """Return ``{canonical_stage: {command: meta}}``.
+
+    The manifest repeats every command under each alias group
+    (``visualize animate`` and ``render animate``). Prefer the entry keyed by
+    the canonical stage so help text quotes the canonical invocation.
+    """
+
+    caps = load_capabilities(capabilities_dir())
+    out: dict[str, dict[str, dict[str, Any]]] = {s: {} for s in STAGE_ORDER}
+    for key, meta in caps.items():
+        if not isinstance(key, str) or " " not in key:
+            continue
+        group, command = key.split(" ", 1)
+        stage = normalize_stage_name(group)
+        if stage not in out:
+            continue
+        if group == stage or command not in out[stage]:
+            out[stage][command] = meta
+    return out
+
+
+def esc(text: Any) -> str:
+    return re.sub(r"\s+", " ", str(text or "")).strip().replace("|", "\\|")
+
+
+def opt_row(flag: str, meta: Any) -> tuple[str, str, str, str, str]:
+    key = flag.lstrip("-").replace("-", "_")
+    if isinstance(meta, str):
+        return key, flag, "str", "", esc(meta)
+    typ = meta.get("type") or "str"
+    default = meta.get("default", "")
+    default = "" if default in (None, "") else f"`{default}`"
+    help_text = esc(meta.get("help", ""))
+    if meta.get("choices"):
+        joined = ", ".join(f"`{c}`" for c in meta["choices"])
+        help_text = (help_text + " " if help_text else "") + f"Choices: {joined}"
+    return key, flag, typ, default, help_text
+
+
+def command_section(stage: str, command: str, meta: dict[str, Any]) -> str:
+    lines = [f"### `{stage} {command}`\n"]
+    desc = esc(meta.get("description") or meta.get("doc") or "")
+    if desc:
+        lines.append(desc + "\n")
+
+    positionals = meta.get("positionals") or []
+    mapped = STAGE_POSITIONALS.get((stage, command), ())
+    unmapped_required = [
+        p["name"] for p in positionals if p.get("required") and p["name"] not in mapped
+    ]
+    if positionals:
+        lines.append("**Positionals**\n")
+        lines.append("| Arg key | Required | Type | Usable in a pipeline stage? |")
+        lines.append("| --- | --- | --- | --- |")
+        for p in positionals:
+            typ = p.get("type") or "str"
+            if p.get("choices"):
+                typ += " (" + ", ".join(f"`{c}`" for c in p["choices"]) + ")"
+            usable = "yes" if p["name"] in mapped else "**no — see note**"
+            required = "yes" if p.get("required") else "no"
+            lines.append(f"| `{p['name']}` | {required} | {typ} | {usable} |")
+        lines.append("")
+    if unmapped_required:
+        names = ", ".join(f"`{n}`" for n in unmapped_required)
+        lines.append(
+            "> **Not pipeline-addressable.** The runner has no positional "
+            f"mapping for this command, so {names} would be emitted as a "
+            "`--flag` and rejected by argparse. Use this command from the CLI, "
+            "or open an issue to add the mapping.\n"
+        )
+
+    rows = [
+        opt_row(flag, m)
+        for flag, m in (meta.get("options") or {}).items()
+        if flag not in SKIP_FLAGS
+    ]
+    if rows:
+        lines.append("**Options**\n")
+        lines.append("| Arg key | CLI flag | Type | Default | Description |")
+        lines.append("| --- | --- | --- | --- | --- |")
+        for key, flag, typ, default, help_text in rows:
+            lines.append(f"| `{key}` | `{flag}` | {typ} | {default} | {help_text} |")
+        lines.append("")
+
+    notes = []
+    if meta.get("stdin_arg"):
+        notes.append(f'reads stdin via `{meta["stdin_arg"]}: "-"`')
+    if meta.get("output_arg"):
+        notes.append(f'writes via `{meta["output_arg"]}`')
+    if notes:
+        lines.append("**Chaining:** " + "; ".join(notes) + ".\n")
+
+    example = meta.get("example_args")
+    if isinstance(example, dict) and example:
+        lines.append("**Example stage**\n")
+        lines.append("```yaml")
+        lines.append(f"- stage: {stage}")
+        lines.append(f"  command: {command}")
+        lines.append("  args:")
+        for key, value in example.items():
+            if isinstance(value, bool):
+                rendered = "true" if value else "false"
+            elif isinstance(value, list):
+                rendered = "[" + ", ".join(str(v) for v in value) + "]"
+            elif isinstance(value, str):
+                rendered = f'"{value}"'
+            else:
+                rendered = value
+            lines.append(f"    {key}: {rendered}")
+        lines.append("```\n")
+    return "\n".join(lines)
+
+
+def stage_page(stage: str, commands: dict[str, dict[str, Any]], version: str) -> str:
+    aliases = [a for a in STAGE_ALIASES[stage] if a != stage]
+    head = [
+        f"# Args Reference — `{stage}`\n",
+        f"{STAGE_BLURB[stage]}\n",
+        (
+            "Aliases accepted for `stage:` — "
+            + ", ".join(f"`{a}`" for a in aliases)
+            + ".\n"
+        )
+        if aliases
+        else "",
+        f"Generated from Zyra **{version}**. See [Pipeline Schema](Pipeline-Schema) "
+        "for how `args` keys become CLI flags.\n",
+        "**Commands:** "
+        + " · ".join(f"[`{c}`](#{stage}-{c})" for c in sorted(commands))
+        + "\n",
+        "---\n",
+    ]
+    body = [command_section(stage, c, commands[c]) for c in sorted(commands)]
+    return "\n".join(part for part in head if part) + "\n".join(body)
+
+
+def index_page(by_stage: dict[str, dict[str, dict[str, Any]]], version: str) -> str:
+    total = sum(len(v) for v in by_stage.values())
+    lines = [
+        "# CLI Args Reference\n",
+        f"Per-command argument reference for every stage command in Zyra "
+        f"**{version}**, generated from the committed capabilities manifest "
+        "rather than written by hand.\n",
+        f"{total} commands across {len(STAGE_ORDER)} stages. For the file format "
+        "itself — top-level keys, how `args` become flags, env expansion, `--set` "
+        "overrides — see [Pipeline Schema](Pipeline-Schema).\n",
+        "| Stage | Aliases | Commands | Page |",
+        "| --- | --- | --- | --- |",
+    ]
+    for stage in STAGE_ORDER:
+        aliases = ", ".join(f"`{a}`" for a in STAGE_ALIASES[stage] if a != stage) or "—"
+        names = ", ".join(f"`{c}`" for c in sorted(by_stage[stage]))
+        page = f"Args-{stage.capitalize()}"
+        lines.append(f"| `{stage}` | {aliases} | {names} | [{page}]({page}) |")
+    lines += [
+        "",
+        "## Regenerating\n",
+        "```bash",
+        "poetry run python scripts/generate_pipeline_docs.py --out-dir ./wiki",
+        "```\n",
+        "## Known gaps\n",
+        "These commands declare a **required positional** that "
+        "`zyra.pipeline_runner._build_argv_for_stage` does not map, so they "
+        "cannot be driven from a pipeline stage at all:\n",
+    ]
+    for stage in STAGE_ORDER:
+        for command, meta in sorted(by_stage[stage].items()):
+            mapped = STAGE_POSITIONALS.get((stage, command), ())
+            missing = [
+                p["name"]
+                for p in (meta.get("positionals") or [])
+                if p.get("required") and p["name"] not in mapped
+            ]
+            if missing:
+                joined = ", ".join(f"`{m}`" for m in missing)
+                lines.append(f"- `{stage} {command}` — {joined}")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--out-dir", type=Path, default=Path("wiki"))
+    ap.add_argument(
+        "--version",
+        default=None,
+        help="Version label for the page headers (default: installed Zyra version)",
+    )
+    ns = ap.parse_args(argv)
+
+    version = ns.version
+    if version is None:
+        from importlib.metadata import PackageNotFoundError, version as pkg_version
+
+        try:
+            version = pkg_version("zyra")
+        except PackageNotFoundError:
+            version = "unknown"
+
+    by_stage = commands_by_stage()
+    ns.out_dir.mkdir(parents=True, exist_ok=True)
+    (ns.out_dir / "CLI-Args-Reference.md").write_text(
+        index_page(by_stage, version), encoding="utf-8"
+    )
+    for stage in STAGE_ORDER:
+        (ns.out_dir / f"Args-{stage.capitalize()}.md").write_text(
+            stage_page(stage, by_stage[stage], version), encoding="utf-8"
+        )
+    print(f"Wrote {len(STAGE_ORDER) + 1} pages to {ns.out_dir}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/generate_pipeline_schema.py
+++ b/scripts/generate_pipeline_schema.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Regenerate the packaged ``zyra run`` JSON Schema.
+
+Writes ``src/zyra/assets/schemas/zyra-pipeline.schema.json`` from the committed
+capabilities manifest. Run with ``--check`` in CI to fail when the artifact is
+stale.
+
+Usage::
+
+    poetry run python scripts/generate_pipeline_schema.py
+    poetry run python scripts/generate_pipeline_schema.py --check
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_OUT = REPO_ROOT / "src" / "zyra" / "assets" / "schemas"
+
+# Prefer the working tree over any installed copy of Zyra.
+sys.path.insert(0, str(REPO_ROOT / "src"))
+
+from zyra.pipeline_schema import SCHEMA_FILENAME, render_schema  # noqa: E402
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--out-dir",
+        type=Path,
+        default=DEFAULT_OUT,
+        help=f"Destination directory (default: {DEFAULT_OUT})",
+    )
+    ap.add_argument(
+        "--check",
+        action="store_true",
+        help="Exit non-zero if the artifact on disk is out of date; write nothing.",
+    )
+    ns = ap.parse_args(argv)
+
+    target = ns.out_dir / SCHEMA_FILENAME
+    rendered = render_schema()
+
+    if ns.check:
+        if not target.exists():
+            print(f"Missing schema artifact: {target}", file=sys.stderr)
+            return 1
+        if target.read_text(encoding="utf-8") != rendered:
+            print(
+                f"{target} is out of date.\n"
+                "Run: poetry run python scripts/generate_pipeline_schema.py",
+                file=sys.stderr,
+            )
+            return 1
+        print(f"{target} is up to date.")
+        return 0
+
+    ns.out_dir.mkdir(parents=True, exist_ok=True)
+    if target.exists() and target.read_text(encoding="utf-8") == rendered:
+        print(f"{target} unchanged.")
+        return 0
+    target.write_text(rendered, encoding="utf-8")
+    print(f"Wrote {target}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/zyra/assets/schemas/zyra-pipeline.schema.json
+++ b/src/zyra/assets/schemas/zyra-pipeline.schema.json
@@ -1,0 +1,777 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/NOAA-GSL/zyra/main/src/zyra/assets/schemas/zyra-pipeline.schema.json",
+  "title": "Zyra run configuration",
+  "description": "Validates any file accepted by `zyra run`: a pipeline config (`stages:`) or a workflow config (`jobs:` / `on:`). Generated from the committed capabilities manifest by scripts/generate_pipeline_schema.py.",
+  "type": "object",
+  "allOf": [
+    {
+      "anyOf": [
+        {
+          "required": [
+            "stages"
+          ]
+        },
+        {
+          "required": [
+            "jobs"
+          ]
+        }
+      ],
+      "$comment": "A config must define either 'stages' (pipeline) or 'jobs' (workflow)."
+    },
+    {
+      "if": {
+        "required": [
+          "stages"
+        ]
+      },
+      "then": {
+        "$ref": "#/$defs/pipeline"
+      }
+    },
+    {
+      "if": {
+        "required": [
+          "jobs"
+        ]
+      },
+      "then": {
+        "$ref": "#/$defs/workflow"
+      }
+    }
+  ],
+  "$defs": {
+    "pipeline": {
+      "type": "object",
+      "title": "Pipeline config",
+      "required": [
+        "stages"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Human-readable label. Not used by the runner."
+        },
+        "description": {
+          "type": "string"
+        },
+        "stages": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/stage"
+          }
+        }
+      },
+      "additionalProperties": true
+    },
+    "stage": {
+      "type": "object",
+      "title": "Pipeline stage",
+      "required": [
+        "stage",
+        "command"
+      ],
+      "properties": {
+        "stage": {
+          "type": "string",
+          "enum": [
+            "acquire",
+            "acquisition",
+            "decide",
+            "decimate",
+            "decimation",
+            "disseminate",
+            "export",
+            "import",
+            "ingest",
+            "narrate",
+            "optimize",
+            "process",
+            "processing",
+            "render",
+            "simulate",
+            "transform",
+            "verify",
+            "visualization",
+            "visualize"
+          ],
+          "description": "Stage name or alias; normalized by _stage_group_alias()."
+        },
+        "command": {
+          "type": "string",
+          "description": "Subcommand within the stage."
+        },
+        "id": {
+          "type": "string",
+          "description": "Optional label echoed by --print-argv-format=json."
+        },
+        "args": {
+          "$ref": "#/$defs/args"
+        }
+      },
+      "additionalProperties": false,
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "stage": {
+                "enum": [
+                  "acquire",
+                  "acquisition",
+                  "import",
+                  "ingest"
+                ]
+              }
+            },
+            "required": [
+              "stage"
+            ]
+          },
+          "then": {
+            "properties": {
+              "command": {
+                "enum": [
+                  "acquire",
+                  "acquisition",
+                  "api",
+                  "ftp",
+                  "http",
+                  "import",
+                  "ingest",
+                  "s3",
+                  "thredds",
+                  "vimeo"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "stage": {
+                "enum": [
+                  "process",
+                  "processing",
+                  "transform"
+                ]
+              }
+            },
+            "required": [
+              "stage"
+            ]
+          },
+          "then": {
+            "properties": {
+              "command": {
+                "enum": [
+                  "api-json",
+                  "audio-metadata",
+                  "audio-transcode",
+                  "convert-format",
+                  "decode-grib2",
+                  "enrich-datasets",
+                  "enrich-metadata",
+                  "extract-variable",
+                  "metadata",
+                  "pad-missing",
+                  "process",
+                  "processing",
+                  "reproject",
+                  "scan-frames",
+                  "transform",
+                  "update-dataset-json",
+                  "video-transcode"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "stage": {
+                "enum": [
+                  "simulate"
+                ]
+              }
+            },
+            "required": [
+              "stage"
+            ]
+          },
+          "then": {
+            "properties": {
+              "command": {
+                "enum": [
+                  "sample",
+                  "simulate"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "stage": {
+                "enum": [
+                  "decide",
+                  "optimize"
+                ]
+              }
+            },
+            "required": [
+              "stage"
+            ]
+          },
+          "then": {
+            "properties": {
+              "command": {
+                "enum": [
+                  "decide",
+                  "optimize"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "stage": {
+                "enum": [
+                  "visualize",
+                  "visualization",
+                  "render"
+                ]
+              }
+            },
+            "required": [
+              "stage"
+            ]
+          },
+          "then": {
+            "properties": {
+              "command": {
+                "enum": [
+                  "animate",
+                  "compose-video",
+                  "contour",
+                  "heatmap",
+                  "interactive",
+                  "render",
+                  "sos",
+                  "timeseries",
+                  "vector",
+                  "visualization",
+                  "visualize"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "stage": {
+                "enum": [
+                  "narrate"
+                ]
+              }
+            },
+            "required": [
+              "stage"
+            ]
+          },
+          "then": {
+            "properties": {
+              "command": {
+                "enum": [
+                  "describe",
+                  "narrate",
+                  "swarm"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "stage": {
+                "enum": [
+                  "verify"
+                ]
+              }
+            },
+            "required": [
+              "stage"
+            ]
+          },
+          "then": {
+            "properties": {
+              "command": {
+                "enum": [
+                  "evaluate",
+                  "verify"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "stage": {
+                "enum": [
+                  "decimate",
+                  "decimation",
+                  "export",
+                  "disseminate"
+                ]
+              }
+            },
+            "required": [
+              "stage"
+            ]
+          },
+          "then": {
+            "properties": {
+              "command": {
+                "enum": [
+                  "decimate",
+                  "decimation",
+                  "disseminate",
+                  "export",
+                  "ftp",
+                  "local",
+                  "post",
+                  "s3",
+                  "vimeo"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "stage": {
+                "enum": [
+                  "acquire",
+                  "acquisition",
+                  "import",
+                  "ingest"
+                ]
+              },
+              "command": {
+                "const": "ftp"
+              }
+            },
+            "required": [
+              "stage",
+              "command"
+            ]
+          },
+          "then": {
+            "properties": {
+              "args": {
+                "required": [
+                  "path"
+                ]
+              }
+            },
+            "required": [
+              "args"
+            ]
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "stage": {
+                "enum": [
+                  "acquire",
+                  "acquisition",
+                  "import",
+                  "ingest"
+                ]
+              },
+              "command": {
+                "const": "http"
+              }
+            },
+            "required": [
+              "stage",
+              "command"
+            ]
+          },
+          "then": {
+            "properties": {
+              "args": {
+                "required": [
+                  "url"
+                ]
+              }
+            },
+            "required": [
+              "args"
+            ]
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "stage": {
+                "enum": [
+                  "decimate",
+                  "decimation",
+                  "export",
+                  "disseminate"
+                ]
+              },
+              "command": {
+                "const": "ftp"
+              }
+            },
+            "required": [
+              "stage",
+              "command"
+            ]
+          },
+          "then": {
+            "properties": {
+              "args": {
+                "required": [
+                  "path"
+                ]
+              }
+            },
+            "required": [
+              "args"
+            ]
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "stage": {
+                "enum": [
+                  "decimate",
+                  "decimation",
+                  "export",
+                  "disseminate"
+                ]
+              },
+              "command": {
+                "const": "local"
+              }
+            },
+            "required": [
+              "stage",
+              "command"
+            ]
+          },
+          "then": {
+            "properties": {
+              "args": {
+                "required": [
+                  "path"
+                ]
+              }
+            },
+            "required": [
+              "args"
+            ]
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "stage": {
+                "enum": [
+                  "decimate",
+                  "decimation",
+                  "export",
+                  "disseminate"
+                ]
+              },
+              "command": {
+                "const": "post"
+              }
+            },
+            "required": [
+              "stage",
+              "command"
+            ]
+          },
+          "then": {
+            "properties": {
+              "args": {
+                "required": [
+                  "url"
+                ]
+              }
+            },
+            "required": [
+              "args"
+            ]
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "stage": {
+                "enum": [
+                  "process",
+                  "processing",
+                  "transform"
+                ]
+              },
+              "command": {
+                "const": "convert-format"
+              }
+            },
+            "required": [
+              "stage",
+              "command"
+            ]
+          },
+          "then": {
+            "properties": {
+              "args": {
+                "required": [
+                  "format"
+                ]
+              }
+            },
+            "required": [
+              "args"
+            ]
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "stage": {
+                "enum": [
+                  "process",
+                  "processing",
+                  "transform"
+                ]
+              },
+              "command": {
+                "const": "decode-grib2"
+              }
+            },
+            "required": [
+              "stage",
+              "command"
+            ]
+          },
+          "then": {
+            "properties": {
+              "args": {
+                "required": [
+                  "file_or_url"
+                ]
+              }
+            },
+            "required": [
+              "args"
+            ]
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "stage": {
+                "enum": [
+                  "process",
+                  "processing",
+                  "transform"
+                ]
+              },
+              "command": {
+                "const": "extract-variable"
+              }
+            },
+            "required": [
+              "stage",
+              "command"
+            ]
+          },
+          "then": {
+            "properties": {
+              "args": {
+                "required": [
+                  "file_or_url",
+                  "pattern"
+                ]
+              }
+            },
+            "required": [
+              "args"
+            ]
+          }
+        }
+      ]
+    },
+    "args": {
+      "type": "object",
+      "description": "Mapping of argument name to value. Keys become `--kebab-case` flags unless the runner maps them to a positional. Nested objects are not supported.",
+      "additionalProperties": {
+        "$ref": "#/$defs/argValue"
+      },
+      "propertyNames": {
+        "pattern": "^[A-Za-z_][A-Za-z0-9_-]*$"
+      }
+    },
+    "argValue": {
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "number"
+        },
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        },
+        {
+          "type": "array",
+          "items": {
+            "type": [
+              "string",
+              "number",
+              "boolean"
+            ]
+          },
+          "description": "Expanded to a multi-valued flag: `--inputs a b`."
+        }
+      ]
+    },
+    "workflow": {
+      "type": "object",
+      "title": "Workflow config",
+      "description": "GitHub-Actions-shaped config with triggers and dependent jobs.",
+      "required": [
+        "jobs"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "on": {
+          "$ref": "#/$defs/on"
+        },
+        "env": {
+          "type": "object",
+          "description": "Exported into the process environment before jobs run, after ${VAR} expansion. Values that still look unresolved are skipped rather than exported.",
+          "additionalProperties": {
+            "type": [
+              "string",
+              "number",
+              "boolean"
+            ]
+          }
+        },
+        "jobs": {
+          "type": "object",
+          "minProperties": 1,
+          "additionalProperties": {
+            "$ref": "#/$defs/job"
+          }
+        }
+      },
+      "additionalProperties": true
+    },
+    "on": {
+      "type": "object",
+      "description": "Trigger section. NOTE: PyYAML parses a bare `on:` key as boolean true; Zyra accepts both. Quote it (`\"on\":`) for portable validation.",
+      "properties": {
+        "schedule": {
+          "type": "array",
+          "items": {
+            "oneOf": [
+              {
+                "type": "object",
+                "required": [
+                  "cron"
+                ],
+                "properties": {
+                  "cron": {
+                    "type": "string"
+                  }
+                }
+              },
+              {
+                "type": "string"
+              }
+            ]
+          }
+        }
+      },
+      "additionalProperties": true
+    },
+    "job": {
+      "type": "object",
+      "required": [
+        "steps"
+      ],
+      "properties": {
+        "needs": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ],
+          "description": "Job names that must succeed first. Cycles are rejected."
+        },
+        "steps": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/step"
+          }
+        }
+      },
+      "additionalProperties": true
+    },
+    "step": {
+      "oneOf": [
+        {
+          "type": "string",
+          "description": "Shell-style argv, split with shlex: `process convert-format - netcdf --stdout`."
+        },
+        {
+          "type": "object",
+          "required": [
+            "cmd"
+          ],
+          "properties": {
+            "cmd": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/stage"
+        }
+      ]
+    }
+  }
+}

--- a/src/zyra/pipeline_schema.py
+++ b/src/zyra/pipeline_schema.py
@@ -1,0 +1,389 @@
+# SPDX-License-Identifier: Apache-2.0
+"""JSON Schema for ``zyra run`` configurations.
+
+``zyra run`` accepts two document shapes:
+
+* a **pipeline** — a ``stages:`` list executed in order, stdout piped to stdin
+* a **workflow** — ``jobs:`` with ``needs:`` dependencies and ``on.schedule``
+  cron triggers
+
+This module builds a draft 2020-12 JSON Schema covering both, so editors, CI,
+and downstream services can validate a config before it is run.
+
+The schema is derived from the **committed** capabilities manifest under
+``zyra/wizard/zyra_capabilities/`` rather than from live argparse
+introspection. That keeps generation deterministic: optional extras (e.g.
+``pydantic`` for ``narrate``) change what ``build_manifest()`` can see at
+runtime, but not what is committed.
+
+The generated artifact is packaged at
+``zyra/assets/schemas/zyra-pipeline.schema.json`` and can be read with
+:func:`load_schema` without regenerating it.
+"""
+
+from __future__ import annotations
+
+import json
+from importlib import resources
+from pathlib import Path
+from typing import Any
+
+from zyra.core.capabilities_loader import load_capabilities
+from zyra.stage_utils import normalize_stage_name
+
+SCHEMA_FILENAME = "zyra-pipeline.schema.json"
+SCHEMA_ID = (
+    "https://raw.githubusercontent.com/NOAA-GSL/zyra/main/"
+    "src/zyra/assets/schemas/zyra-pipeline.schema.json"
+)
+
+#: Canonical stage name -> every alias accepted for ``stage:``.
+#: Kept in sync with :func:`zyra.pipeline_runner._stage_group_alias` by
+#: ``tests/test_pipeline_schema.py``.
+STAGE_ALIASES: dict[str, tuple[str, ...]] = {
+    "acquire": ("acquire", "acquisition", "import", "ingest"),
+    "process": ("process", "processing", "transform"),
+    "simulate": ("simulate",),
+    "decide": ("decide", "optimize"),
+    "visualize": ("visualize", "visualization", "render"),
+    "narrate": ("narrate",),
+    "verify": ("verify",),
+    "decimate": ("decimate", "decimation", "export", "disseminate"),
+}
+
+#: (canonical stage, command) -> args consumed as positionals, in order.
+#: Mirrors the positional table in
+#: :func:`zyra.pipeline_runner._build_argv_for_stage`; a command absent here
+#: cannot receive a positional from a pipeline stage, because every remaining
+#: arg is emitted as ``--kebab-case``. Kept honest by
+#: ``test_positionals_match_runner``.
+STAGE_POSITIONALS: dict[tuple[str, str], tuple[str, ...]] = {
+    ("acquire", "http"): ("url",),
+    ("acquire", "ftp"): ("path",),
+    ("process", "convert-format"): ("file_or_url", "format"),
+    ("process", "decode-grib2"): ("file_or_url",),
+    ("process", "extract-variable"): ("file_or_url", "pattern"),
+    ("decimate", "local"): ("path",),
+    ("decimate", "ftp"): ("path",),
+    ("decimate", "post"): ("url",),
+}
+
+
+def capabilities_dir() -> Path:
+    """Return the packaged capabilities manifest directory."""
+
+    return Path(str(resources.files("zyra.wizard") / "zyra_capabilities"))
+
+
+def schema_path() -> Path:
+    """Return the packaged schema artifact path."""
+
+    return Path(str(resources.files("zyra") / "assets" / "schemas" / SCHEMA_FILENAME))
+
+
+def load_schema() -> dict[str, Any]:
+    """Load the packaged schema artifact."""
+
+    return json.loads(schema_path().read_text(encoding="utf-8"))
+
+
+def commands_by_stage(
+    capabilities: dict[str, Any] | None = None,
+) -> dict[str, list[str]]:
+    """Return ``{canonical_stage: [command, ...]}`` from the manifest.
+
+    Alias groups (``import``/``render``/``export``/...) collapse into their
+    canonical stage; non-stage top-level commands (``run``, ``search``) are
+    ignored.
+    """
+
+    caps = (
+        capabilities
+        if capabilities is not None
+        else load_capabilities(capabilities_dir())
+    )
+    out: dict[str, set[str]] = {stage: set() for stage in STAGE_ALIASES}
+    for key in caps:
+        if not isinstance(key, str) or " " not in key:
+            continue
+        group, command = key.split(" ", 1)
+        stage = normalize_stage_name(group)
+        if stage in out:
+            out[stage].add(command)
+    return {stage: sorted(names) for stage, names in out.items()}
+
+
+def _stage_rules(by_stage: dict[str, list[str]]) -> list[dict[str, Any]]:
+    """Constrain ``command`` to the commands valid for the given ``stage``."""
+
+    rules: list[dict[str, Any]] = []
+    for stage, commands in by_stage.items():
+        aliases = list(STAGE_ALIASES[stage])
+        # `stage: acquire` + `args.backend: http` selects the subcommand, so the
+        # group name itself is a legal `command` value.
+        allowed = sorted(set(commands) | set(aliases))
+        rules.append(
+            {
+                "if": {
+                    "properties": {"stage": {"enum": aliases}},
+                    "required": ["stage"],
+                },
+                "then": {"properties": {"command": {"enum": allowed}}},
+            }
+        )
+    return rules
+
+
+def _positional_rules(capabilities: dict[str, Any]) -> list[dict[str, Any]]:
+    """Require positional args that the runner maps and the CLI requires."""
+
+    rules: list[dict[str, Any]] = []
+    for (stage, command), names in sorted(STAGE_POSITIONALS.items()):
+        meta = capabilities.get(f"{stage} {command}") or {}
+        if not meta:
+            # Alias-keyed manifests (e.g. `disseminate local`) still describe the
+            # same command; fall back to the first alias that resolves.
+            for alias in STAGE_ALIASES[stage]:
+                meta = capabilities.get(f"{alias} {command}") or {}
+                if meta:
+                    break
+        required = [
+            p["name"]
+            for p in (meta.get("positionals") or [])
+            if p.get("required") and p.get("name") in names
+        ]
+        if not required:
+            continue
+        rules.append(
+            {
+                "if": {
+                    "properties": {
+                        "stage": {"enum": list(STAGE_ALIASES[stage])},
+                        "command": {"const": command},
+                    },
+                    "required": ["stage", "command"],
+                },
+                "then": {
+                    "properties": {"args": {"required": required}},
+                    "required": ["args"],
+                },
+            }
+        )
+    return rules
+
+
+def build_schema(capabilities: dict[str, Any] | None = None) -> dict[str, Any]:
+    """Build the JSON Schema for ``zyra run`` configurations."""
+
+    caps = (
+        capabilities
+        if capabilities is not None
+        else load_capabilities(capabilities_dir())
+    )
+    by_stage = commands_by_stage(caps)
+    all_aliases = sorted({a for aliases in STAGE_ALIASES.values() for a in aliases})
+
+    return {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$id": SCHEMA_ID,
+        "title": "Zyra run configuration",
+        "description": (
+            "Validates any file accepted by `zyra run`: a pipeline config "
+            "(`stages:`) or a workflow config (`jobs:` / `on:`). Generated from "
+            "the committed capabilities manifest by "
+            "scripts/generate_pipeline_schema.py."
+        ),
+        "type": "object",
+        # Dispatch on the discriminating key rather than a bare oneOf, so
+        # validators report the offending field instead of
+        # "is not valid under any of the given schemas".
+        "allOf": [
+            {
+                "anyOf": [{"required": ["stages"]}, {"required": ["jobs"]}],
+                "$comment": (
+                    "A config must define either 'stages' (pipeline) or 'jobs' "
+                    "(workflow)."
+                ),
+            },
+            {"if": {"required": ["stages"]}, "then": {"$ref": "#/$defs/pipeline"}},
+            {"if": {"required": ["jobs"]}, "then": {"$ref": "#/$defs/workflow"}},
+        ],
+        "$defs": {
+            "pipeline": {
+                "type": "object",
+                "title": "Pipeline config",
+                "required": ["stages"],
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "description": "Human-readable label. Not used by the runner.",
+                    },
+                    "description": {"type": "string"},
+                    "stages": {
+                        "type": "array",
+                        "minItems": 1,
+                        "items": {"$ref": "#/$defs/stage"},
+                    },
+                },
+                "additionalProperties": True,
+            },
+            "stage": {
+                "type": "object",
+                "title": "Pipeline stage",
+                "required": ["stage", "command"],
+                "properties": {
+                    "stage": {
+                        "type": "string",
+                        "enum": all_aliases,
+                        "description": "Stage name or alias; normalized by _stage_group_alias().",
+                    },
+                    "command": {
+                        "type": "string",
+                        "description": "Subcommand within the stage.",
+                    },
+                    "id": {
+                        "type": "string",
+                        "description": "Optional label echoed by --print-argv-format=json.",
+                    },
+                    "args": {"$ref": "#/$defs/args"},
+                },
+                "additionalProperties": False,
+                "allOf": _stage_rules(by_stage) + _positional_rules(caps),
+            },
+            "args": {
+                "type": "object",
+                "description": (
+                    "Mapping of argument name to value. Keys become "
+                    "`--kebab-case` flags unless the runner maps them to a "
+                    "positional. Nested objects are not supported."
+                ),
+                "additionalProperties": {"$ref": "#/$defs/argValue"},
+                "propertyNames": {"pattern": "^[A-Za-z_][A-Za-z0-9_-]*$"},
+            },
+            "argValue": {
+                "oneOf": [
+                    {"type": "string"},
+                    {"type": "number"},
+                    {"type": "boolean"},
+                    {"type": "null"},
+                    {
+                        "type": "array",
+                        "items": {"type": ["string", "number", "boolean"]},
+                        "description": "Expanded to a multi-valued flag: `--inputs a b`.",
+                    },
+                ]
+            },
+            "workflow": {
+                "type": "object",
+                "title": "Workflow config",
+                "description": (
+                    "GitHub-Actions-shaped config with triggers and dependent jobs."
+                ),
+                "required": ["jobs"],
+                "properties": {
+                    "name": {"type": "string"},
+                    "on": {"$ref": "#/$defs/on"},
+                    "env": {
+                        "type": "object",
+                        "description": (
+                            "Exported into the process environment before jobs "
+                            "run, after ${VAR} expansion. Values that still look "
+                            "unresolved are skipped rather than exported."
+                        ),
+                        "additionalProperties": {
+                            "type": ["string", "number", "boolean"]
+                        },
+                    },
+                    "jobs": {
+                        "type": "object",
+                        "minProperties": 1,
+                        "additionalProperties": {"$ref": "#/$defs/job"},
+                    },
+                },
+                "additionalProperties": True,
+            },
+            "on": {
+                "type": "object",
+                "description": (
+                    "Trigger section. NOTE: PyYAML parses a bare `on:` key as "
+                    'boolean true; Zyra accepts both. Quote it (`"on":`) for '
+                    "portable validation."
+                ),
+                "properties": {
+                    "schedule": {
+                        "type": "array",
+                        "items": {
+                            "oneOf": [
+                                {
+                                    "type": "object",
+                                    "required": ["cron"],
+                                    "properties": {"cron": {"type": "string"}},
+                                },
+                                {"type": "string"},
+                            ]
+                        },
+                    }
+                },
+                "additionalProperties": True,
+            },
+            "job": {
+                "type": "object",
+                "required": ["steps"],
+                "properties": {
+                    "needs": {
+                        "oneOf": [
+                            {"type": "string"},
+                            {"type": "array", "items": {"type": "string"}},
+                        ],
+                        "description": (
+                            "Job names that must succeed first. Cycles are rejected."
+                        ),
+                    },
+                    "steps": {
+                        "type": "array",
+                        "minItems": 1,
+                        "items": {"$ref": "#/$defs/step"},
+                    },
+                },
+                "additionalProperties": True,
+            },
+            "step": {
+                "oneOf": [
+                    {
+                        "type": "string",
+                        "description": (
+                            "Shell-style argv, split with shlex: "
+                            "`process convert-format - netcdf --stdout`."
+                        ),
+                    },
+                    {
+                        "type": "object",
+                        "required": ["cmd"],
+                        "properties": {"cmd": {"type": "string"}},
+                        "additionalProperties": False,
+                    },
+                    {"$ref": "#/$defs/stage"},
+                ]
+            },
+        },
+    }
+
+
+def render_schema(capabilities: dict[str, Any] | None = None) -> str:
+    """Return the schema serialized exactly as the committed artifact."""
+
+    return json.dumps(build_schema(capabilities), indent=2, sort_keys=False) + "\n"
+
+
+__all__ = [
+    "SCHEMA_FILENAME",
+    "SCHEMA_ID",
+    "STAGE_ALIASES",
+    "STAGE_POSITIONALS",
+    "build_schema",
+    "capabilities_dir",
+    "commands_by_stage",
+    "load_schema",
+    "render_schema",
+    "schema_path",
+]

--- a/tests/test_pipeline_schema.py
+++ b/tests/test_pipeline_schema.py
@@ -89,9 +89,9 @@ def test_every_manifest_stage_is_covered() -> None:
     groups = {k.split(" ", 1)[0] for k in caps if isinstance(k, str) and " " in k}
     # `search` and `run` are top-level commands, not pipeline stages.
     stages = {_stage_group_alias(g) for g in groups} - {"search", "run"}
-    assert stages <= set(STAGE_ALIASES), (
-        f"Stages missing from STAGE_ALIASES: {sorted(stages - set(STAGE_ALIASES))}"
-    )
+    assert stages <= set(
+        STAGE_ALIASES
+    ), f"Stages missing from STAGE_ALIASES: {sorted(stages - set(STAGE_ALIASES))}"
 
 
 def _consumes_positionally(stage: str, command: str, arg: str) -> bool:
@@ -147,13 +147,11 @@ def test_positional_order_is_preserved() -> None:
         if len(names) < 2:
             continue
         args = {name: f"P{i}" for i, name in enumerate(names)}
-        argv = _build_argv_for_stage(
-            {"stage": stage, "command": command, "args": args}
-        )
+        argv = _build_argv_for_stage({"stage": stage, "command": command, "args": args})
         expected = [f"P{i}" for i in range(len(names))]
-        assert argv[2 : 2 + len(names)] == expected, (
-            f"{stage} {command}: positional order {argv[2:]} != {expected}"
-        )
+        assert (
+            argv[2 : 2 + len(names)] == expected
+        ), f"{stage} {command}: positional order {argv[2:]} != {expected}"
 
 
 # --------------------------------------------------------------------------

--- a/tests/test_pipeline_schema.py
+++ b/tests/test_pipeline_schema.py
@@ -1,0 +1,261 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the packaged ``zyra run`` JSON Schema.
+
+Four things are checked:
+
+1. the committed artifact matches what the generator produces (drift),
+2. the alias table matches the runner's own stage normalization,
+3. the positional table matches what the runner actually consumes positionally,
+4. every sample config validates, and malformed configs are rejected.
+
+(4) needs ``jsonschema``, which is not a declared dependency, so those tests
+skip when it is unavailable. (1)-(3) always run.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from zyra.core.capabilities_loader import load_capabilities
+from zyra.pipeline_runner import _build_argv_for_stage, _stage_group_alias
+from zyra.pipeline_schema import (
+    STAGE_ALIASES,
+    STAGE_POSITIONALS,
+    build_schema,
+    capabilities_dir,
+    render_schema,
+    schema_path,
+)
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SAMPLE_DIRS = (REPO_ROOT / "samples" / "pipelines", REPO_ROOT / "samples" / "workflows")
+SAMPLES = sorted(
+    p
+    for directory in SAMPLE_DIRS
+    for p in directory.glob("*")
+    if p.is_file() and p.suffix in {".yaml", ".yml", ".json"}
+)
+
+# Commands whose required positional the runner cannot express in a pipeline
+# stage. Adding a command here should be a deliberate act: prefer teaching
+# `_build_argv_for_stage` the mapping and adding it to STAGE_POSITIONALS.
+KNOWN_UNMAPPED_POSITIONALS = {
+    ("acquire", "thredds"): {"catalog_url"},
+    ("acquire", "vimeo"): {"video_id"},
+    ("process", "api-json"): {"file_or_url"},
+    ("process", "audio-metadata"): {"input"},
+    ("process", "audio-transcode"): {"input"},
+    ("process", "video-transcode"): {"input"},
+}
+
+
+def test_schema_artifact_matches_generator() -> None:
+    """The committed schema is current.
+
+    Regenerate with: poetry run python scripts/generate_pipeline_schema.py
+    """
+
+    target = schema_path()
+    assert target.exists(), f"Missing schema artifact: {target}"
+    assert target.read_text(encoding="utf-8") == render_schema(), (
+        "Schema artifact is stale. Run "
+        "`poetry run python scripts/generate_pipeline_schema.py`."
+    )
+
+
+def test_schema_is_valid_json() -> None:
+    data = json.loads(schema_path().read_text(encoding="utf-8"))
+    assert data["$schema"] == "https://json-schema.org/draft/2020-12/schema"
+    assert data["$id"].endswith("zyra-pipeline.schema.json")
+
+
+@pytest.mark.parametrize(
+    ("canonical", "alias"),
+    [(c, a) for c, aliases in STAGE_ALIASES.items() for a in aliases],
+)
+def test_stage_aliases_match_runner(canonical: str, alias: str) -> None:
+    """STAGE_ALIASES agrees with the runner's own normalization."""
+
+    assert _stage_group_alias(alias) == canonical
+
+
+def test_every_manifest_stage_is_covered() -> None:
+    """No stage in the manifest is missing from STAGE_ALIASES."""
+
+    caps = load_capabilities(capabilities_dir())
+    groups = {k.split(" ", 1)[0] for k in caps if isinstance(k, str) and " " in k}
+    # `search` and `run` are top-level commands, not pipeline stages.
+    stages = {_stage_group_alias(g) for g in groups} - {"search", "run"}
+    assert stages <= set(STAGE_ALIASES), (
+        f"Stages missing from STAGE_ALIASES: {sorted(stages - set(STAGE_ALIASES))}"
+    )
+
+
+def _consumes_positionally(stage: str, command: str, arg: str) -> bool:
+    """True when the runner emits ``arg``'s value as a bare argv element."""
+
+    argv = _build_argv_for_stage(
+        {"stage": stage, "command": command, "args": {arg: "PROBE"}}
+    )
+    flag = "--" + arg.replace("_", "-")
+    return "PROBE" in argv and flag not in argv
+
+
+def test_positionals_match_runner() -> None:
+    """STAGE_POSITIONALS matches what the runner actually does.
+
+    Also asserts that any command whose required positional the runner cannot
+    map is a known gap, so a new one cannot appear silently.
+    """
+
+    caps = load_capabilities(capabilities_dir())
+    unmapped: dict[tuple[str, str], set[str]] = {}
+
+    for key, meta in caps.items():
+        if not isinstance(key, str) or " " not in key:
+            continue
+        group, command = key.split(" ", 1)
+        stage = _stage_group_alias(group)
+        if stage not in STAGE_ALIASES:
+            continue
+        mapped = STAGE_POSITIONALS.get((stage, command), ())
+        for positional in meta.get("positionals") or []:
+            name = positional["name"]
+            consumed = _consumes_positionally(group, command, name)
+            assert consumed == (name in mapped), (
+                f"{stage} {command}: arg {name!r} is "
+                f"{'consumed' if consumed else 'not consumed'} positionally by the "
+                f"runner but STAGE_POSITIONALS says otherwise"
+            )
+            if positional.get("required") and not consumed:
+                unmapped.setdefault((stage, command), set()).add(name)
+
+    assert unmapped == KNOWN_UNMAPPED_POSITIONALS, (
+        "Set of commands with unmappable required positionals changed.\n"
+        f"  now:      {sorted(unmapped.items())}\n"
+        f"  expected: {sorted(KNOWN_UNMAPPED_POSITIONALS.items())}"
+    )
+
+
+def test_positional_order_is_preserved() -> None:
+    """Multi-positional commands emit their args in the declared order."""
+
+    for (stage, command), names in STAGE_POSITIONALS.items():
+        if len(names) < 2:
+            continue
+        args = {name: f"P{i}" for i, name in enumerate(names)}
+        argv = _build_argv_for_stage(
+            {"stage": stage, "command": command, "args": args}
+        )
+        expected = [f"P{i}" for i in range(len(names))]
+        assert argv[2 : 2 + len(names)] == expected, (
+            f"{stage} {command}: positional order {argv[2:]} != {expected}"
+        )
+
+
+# --------------------------------------------------------------------------
+# Validation against real documents (requires jsonschema)
+# --------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def validator():
+    jsonschema = pytest.importorskip("jsonschema")
+    schema = build_schema()
+    jsonschema.Draft202012Validator.check_schema(schema)
+    return jsonschema.Draft202012Validator(schema)
+
+
+def _load_doc(path: Path):
+    import yaml
+
+    return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+
+@pytest.mark.parametrize("path", SAMPLES, ids=lambda p: p.name)
+def test_samples_validate(validator, path: Path) -> None:
+    doc = _load_doc(path)
+    if not isinstance(doc, dict) or not ({"stages", "jobs"} & set(doc)):
+        pytest.skip(f"{path.name} is not a run config")
+    errors = sorted(validator.iter_errors(doc), key=lambda e: list(e.path))
+    assert not errors, "\n".join(
+        f"/{'/'.join(str(p) for p in e.path)}: {e.message}" for e in errors[:5]
+    )
+
+
+MALFORMED = {
+    "unknown stage": {"stages": [{"stage": "acquiree", "command": "http"}]},
+    "command not valid for stage": {
+        "stages": [{"stage": "acquire", "command": "heatmap", "args": {"url": "x"}}]
+    },
+    "missing required positional": {
+        "stages": [{"stage": "acquire", "command": "http", "args": {"output": "-"}}]
+    },
+    "nested object arg": {
+        "stages": [
+            {"stage": "acquire", "command": "http", "args": {"url": "x", "o": {"a": 1}}}
+        ]
+    },
+    "args is not a mapping": {
+        "stages": [{"stage": "acquire", "command": "http", "args": ["url"]}]
+    },
+    "unknown stage key": {
+        "stages": [
+            {"stage": "acquire", "command": "http", "args": {"url": "x"}, "retries": 3}
+        ]
+    },
+    "empty stages": {"stages": []},
+    "neither stages nor jobs": {"name": "nothing"},
+    "job without steps": {"jobs": {"a": {"needs": "b"}}},
+    "unrecognized step shape": {"jobs": {"a": {"steps": [{"nope": 1}]}}},
+}
+
+
+@pytest.mark.parametrize("name", sorted(MALFORMED))
+def test_rejects_malformed(validator, name: str) -> None:
+    assert list(validator.iter_errors(MALFORMED[name])), f"{name} should not validate"
+
+
+WELL_FORMED = {
+    "backend selects subcommand": {
+        "stages": [
+            {
+                "stage": "acquire",
+                "command": "acquire",
+                "args": {"backend": "http", "url": "x"},
+            }
+        ]
+    },
+    "alias stage with id": {
+        "stages": [
+            {
+                "stage": "decimation",
+                "command": "local",
+                "id": "out",
+                "args": {"path": "/tmp/x", "input": "-"},
+            }
+        ]
+    },
+    "workflow with string steps": {
+        "on": {"schedule": [{"cron": "5 12 * * 4"}]},
+        "jobs": {"a": {"steps": ["acquire http https://x --output -"]}},
+    },
+    "list-valued arg": {
+        "stages": [
+            {
+                "stage": "visualize",
+                "command": "sos",
+                "args": {"inputs": ["a.nc", "b.nc"], "vmin": 0, "vmax": 50},
+            }
+        ]
+    },
+}
+
+
+@pytest.mark.parametrize("name", sorted(WELL_FORMED))
+def test_accepts_well_formed(validator, name: str) -> None:
+    errors = list(validator.iter_errors(WELL_FORMED[name]))
+    assert not errors, errors[0].message


### PR DESCRIPTION
## Why

There is no machine-readable contract for the files `zyra run` accepts. The format is documented narratively in [Pipeline Patterns](https://github.com/NOAA-GSL/zyra/blob/main/docs/source/wiki/Pipeline-Patterns.md) and demonstrated in `samples/`, but nothing validates a config before it runs, and downstream consumers (TerraViz's `/publish/workflows/{id}/validate`, editors, CI) each maintain their own hand-written allowlist that drifts from the CLI.

This adds a draft 2020-12 JSON Schema covering **both** shapes `zyra run` accepts — pipeline (`stages:`) and workflow (`jobs:` / `on:`) — generated from the committed capabilities manifest rather than written by hand.

Companion wiki pages (`Pipeline-Schema`, `CLI-Args-Reference`, `Args-*`) are already published.

## What's here

| File | Purpose |
| --- | --- |
| `src/zyra/pipeline_schema.py` | Schema builder, plus the `STAGE_ALIASES` and `STAGE_POSITIONALS` tables that mirror `pipeline_runner` |
| `src/zyra/assets/schemas/zyra-pipeline.schema.json` | Generated artifact — ships in the wheel via the existing `src/zyra/assets/**` include |
| `scripts/generate_pipeline_schema.py` | Regenerate; `--check` exits non-zero when stale |
| `scripts/generate_pipeline_docs.py` | Regenerate the wiki args reference from the same manifest |
| `tests/test_pipeline_schema.py` | Drift, alias, positional, and validation coverage |
| `.pre-commit-config.yaml` | Regeneration hook alongside the existing manifest hook |

### Design notes

**Generated from the committed manifest, not live introspection.** `build_manifest()` sees a different command set depending on which optional extras are installed — without `pydantic`, the two `narrate` commands silently vanish. Reading `zyra/wizard/zyra_capabilities/*.json` instead makes generation deterministic in any environment, which is what lets the drift test be a hard assertion.

**Packaged under `assets/`, not a new top-level `schemas/`.** Follows `assets/profiles/` and `assets/metadata/`, is already covered by the `include` in `pyproject.toml`, and means the schema is loadable via `zyra.pipeline_schema.load_schema()` rather than only fetchable over HTTP.

**`if`/`then` dispatch instead of a bare `oneOf`.** With `oneOf`, every error collapses to "is not valid under any of the given schemas". Dispatching on `stages` vs `jobs` gives errors that point at the field:

```
/stages/0/stage    'acquiree' is not one of ['acquire', 'acquisition', ...]
/stages/0/command  'heatmap' is not one of [...]        # wrong command for that stage
/stages/0/args     'url' is a required property         # missing positional
```

**No runtime behavior changes.** Nothing in `pipeline_runner.py` is touched. `STAGE_POSITIONALS` duplicates the runner's positional table, and `test_positionals_match_runner` probes `_build_argv_for_stage` for every command in the manifest to assert the two agree in both directions — so the duplication cannot drift silently. Folding the table into the runner itself would be a reasonable follow-up.

## What the schema checks

- the file is a pipeline or a workflow, and matches that shape
- `stage` is a known stage or alias
- `command` is valid **for that stage** — each stage carries its own command enum
- required positionals are present for the eight commands the runner maps
- `args` values are scalars, `null`, or flat arrays — never nested objects (which stringify into garbage)
- job `steps` are one of the three accepted forms (argv string, `{cmd:}`, or a stage mapping)

It does **not** validate `args` keys per command; that surface lives in the wiki reference. Emitting per-command arg schemas from the manifest is the obvious next step.

## Testing

All 13 configs under `samples/pipelines/` and `samples/workflows/` validate. Ten malformed documents are rejected, four tricky-but-valid ones accepted (`backend`-selected subcommand, alias stage names, workflow string steps, list-valued args). Tampering with the committed artifact fails `test_schema_artifact_matches_generator`.

`jsonschema` is not a declared dev dependency, so the validation tests `importorskip` it; the drift, alias, and positional tests always run. Happy to add it to the dev group instead if you'd prefer those to be enforced.

## Two things surfaced along the way

1. **`samples/pipelines/thredds_to_local.yaml` cannot run.** `_build_argv_for_stage` has no positional mapping for `acquire thredds`, so `catalog_url:` is emitted as `--catalog-url` and argparse rejects it with `unrecognized arguments`. Five other commands have the same defect: `acquire vimeo`, `process api-json`, `process audio-metadata`, `process audio-transcode`, `process video-transcode`. `KNOWN_UNMAPPED_POSITIONALS` in the test pins the current set so no new one appears silently — but the sample is broken today and worth a separate fix.

2. **`narrate` needs `pydantic`** — `zyra narrate` raises `ModuleNotFoundError` without it, and anything generating docs or an allowlist from the live manifest silently loses those commands.

Happy to file both as issues if you'd rather track them separately.

---

Per the mirror README this targets `mirror/staging` for relay into `NOAA-GSL/zyra:staging`. Commits are DCO signed-off.
